### PR TITLE
Basic SMBv2 signing implementation

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
@@ -28,6 +28,8 @@ import static com.hierynomus.smbj.connection.NegotiatedProtocol.SINGLE_CREDIT_PA
  */
 public class SMB2Header {
     public static final int STRUCTURE_SIZE = 64;
+    public static final int SIGNATURE_OFFSET = 48;
+    public static final int SIGNATURE_SIZE = 16;
 
     private SMB2Dialect dialect;
     private int creditCharge = 1;
@@ -137,6 +139,10 @@ public class SMB2Header {
         this.dialect = dialect;
     }
 
+    public boolean isFlagSet(SMB2MessageFlag flag) {
+        return ((this.flags & flag.getValue()) != 0);
+    }
+    
     public void setFlag(SMB2MessageFlag flag) {
         this.flags |= flag.getValue();
     }
@@ -204,5 +210,24 @@ public class SMB2Header {
 
     public void setCreditCharge(int creditCharge) {
         this.creditCharge = creditCharge;
+    }
+    
+    public String toString() {
+        return String.format(
+        "dialect=%s, creditCharge=%s, creditRequest=%s, creditResponse=%s, message=%s, messageId=%s, asyncId=%s, sessionId=%s, treeId=%s, status=%s, statusCode=%s, flags=%s, nextCommandOffset=%s",
+        dialect,
+        creditCharge,
+        creditRequest,
+        creditResponse,
+        message,
+        messageId,
+        asyncId,
+        sessionId,
+        treeId,
+        status,
+        statusCode,
+        flags,
+        nextCommandOffset);
+
     }
 }

--- a/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
@@ -141,7 +141,7 @@ public class SMB2Header {
     }
 
     public boolean isFlagSet(SMB2MessageFlag flag) {
-        return EnumWithValue.EnumUtils.isSet(this.flags, flag);
+        return isSet(this.flags, flag);
     }
     
     public void setFlag(SMB2MessageFlag flag) {

--- a/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
@@ -16,6 +16,7 @@
 package com.hierynomus.mssmb2;
 
 import com.hierynomus.mserref.NtStatus;
+import com.hierynomus.protocol.commons.EnumWithValue;
 import com.hierynomus.protocol.commons.buffer.Buffer;
 import com.hierynomus.smbj.common.SMBBuffer;
 
@@ -140,7 +141,7 @@ public class SMB2Header {
     }
 
     public boolean isFlagSet(SMB2MessageFlag flag) {
-        return ((this.flags & flag.getValue()) != 0);
+        return EnumWithValue.EnumUtils.isSet(this.flags, flag);
     }
     
     public void setFlag(SMB2MessageFlag flag) {

--- a/src/main/java/com/hierynomus/mssmb2/SMB2Packet.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Packet.java
@@ -22,6 +22,7 @@ import com.hierynomus.smbj.common.SMBBuffer;
 public class SMB2Packet implements Packet<SMB2Packet, SMBBuffer> {
     protected final SMB2Header header = new SMB2Header();
     protected int structureSize;
+    SMBBuffer buffer;
 
     public SMB2Packet() {
     }
@@ -54,6 +55,10 @@ public class SMB2Packet implements Packet<SMB2Packet, SMBBuffer> {
         return structureSize;
     }
 
+    public SMBBuffer getBuffer() {
+        return buffer;
+    }
+
     public final void write(SMBBuffer buffer) {
         header.writeTo(buffer);
         writeTo(buffer);
@@ -68,6 +73,7 @@ public class SMB2Packet implements Packet<SMB2Packet, SMBBuffer> {
     }
 
     public final SMB2Packet read(SMBBuffer buffer) throws Buffer.BufferException {
+        this.buffer = buffer; // remember the buffer we read it from
         header.readFrom(buffer);
         readMessage(buffer);
         return this;

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2SessionSetup.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2SessionSetup.java
@@ -59,9 +59,10 @@ public class SMB2SessionSetup extends SMB2Packet {
         buffer.putUInt32(clientCapabilities & 0x01); // Capabilities (4 bytes) (only last byte can be set)
         buffer.putReserved4(); // Channel (4 bytes)
         buffer.putUInt16(SMB2Header.STRUCTURE_SIZE + 25 - 1); // SecurityBufferOffset (2 bytes) (header structure size + Session setup structure size - 1)
-        buffer.putUInt16(securityBuffer.length); // SecurityBufferLength (2 bytes)
+        buffer.putUInt16((securityBuffer!=null)?securityBuffer.length:0); // SecurityBufferLength (2 bytes)
         buffer.putUInt64(previousSessionId); // PreviousSessionId (8 bytes)
-        buffer.putRawBytes(securityBuffer); // SecurityBuffer (variable)
+        if (securityBuffer != null)
+            buffer.putRawBytes(securityBuffer); // SecurityBuffer (variable)
     }
 
     @Override
@@ -82,7 +83,9 @@ public class SMB2SessionSetup extends SMB2Packet {
             buffer.rpos(securityBufferOffset);
             return buffer.readRawBytes(securityBufferLength);
         }
-        throw new SMBRuntimeException("The SMB2 Session Setup response should contain a positive length security buffer");
+        else
+            return new byte[0];
+//        throw new SMBRuntimeException("The SMB2 Session Setup response should contain a positive length security buffer");
     }
 
     private void putFlags(SMBBuffer buffer) {

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2SessionSetup.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2SessionSetup.java
@@ -59,10 +59,11 @@ public class SMB2SessionSetup extends SMB2Packet {
         buffer.putUInt32(clientCapabilities & 0x01); // Capabilities (4 bytes) (only last byte can be set)
         buffer.putReserved4(); // Channel (4 bytes)
         buffer.putUInt16(SMB2Header.STRUCTURE_SIZE + 25 - 1); // SecurityBufferOffset (2 bytes) (header structure size + Session setup structure size - 1)
-        buffer.putUInt16((securityBuffer!=null)?securityBuffer.length:0); // SecurityBufferLength (2 bytes)
+        buffer.putUInt16((securityBuffer!=null) ? securityBuffer.length : 0); // SecurityBufferLength (2 bytes)
         buffer.putUInt64(previousSessionId); // PreviousSessionId (8 bytes)
-        if (securityBuffer != null)
+        if (securityBuffer != null) {
             buffer.putRawBytes(securityBuffer); // SecurityBuffer (variable)
+        }
     }
 
     @Override
@@ -82,10 +83,10 @@ public class SMB2SessionSetup extends SMB2Packet {
             // Just to be sure, we should already be there.
             buffer.rpos(securityBufferOffset);
             return buffer.readRawBytes(securityBufferLength);
-        }
-        else
+        } else {
             return new byte[0];
 //        throw new SMBRuntimeException("The SMB2 Session Setup response should contain a positive length security buffer");
+        }
     }
 
     private void putFlags(SMBBuffer buffer) {

--- a/src/main/java/com/hierynomus/protocol/commons/socket/SocketClient.java
+++ b/src/main/java/com/hierynomus/protocol/commons/socket/SocketClient.java
@@ -25,6 +25,8 @@ import java.net.InetAddress;
 import java.net.Socket;
 
 public abstract class SocketClient {
+    private static final int INITIAL_BUFFER_SIZE = 9000; // Size of a Jumbo frame.
+
     private final int defaultPort;
 
     private Socket socket;
@@ -117,7 +119,7 @@ public abstract class SocketClient {
     protected void onConnect() throws IOException {
         socket.setSoTimeout(soTimeout);
         input = socket.getInputStream();
-        output = new BufferedOutputStream(socket.getOutputStream(), 2500); //TODO: default number (better to be close to Ethernet frame size?)
+        output = new BufferedOutputStream(socket.getOutputStream(), INITIAL_BUFFER_SIZE);
     }
 
     public int getRemotePort() {

--- a/src/main/java/com/hierynomus/protocol/commons/socket/SocketClient.java
+++ b/src/main/java/com/hierynomus/protocol/commons/socket/SocketClient.java
@@ -16,6 +16,8 @@
 package com.hierynomus.protocol.commons.socket;
 
 import javax.net.SocketFactory;
+
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -115,7 +117,7 @@ public abstract class SocketClient {
     protected void onConnect() throws IOException {
         socket.setSoTimeout(soTimeout);
         input = socket.getInputStream();
-        output = socket.getOutputStream();
+        output = new BufferedOutputStream(socket.getOutputStream(), 2500); //TODO: default number (better to be close to Ethernet frame size?)
     }
 
     public int getRemotePort() {

--- a/src/main/java/com/hierynomus/smbj/Config.java
+++ b/src/main/java/com/hierynomus/smbj/Config.java
@@ -28,4 +28,10 @@ public interface Config {
     EnumSet<SMB2Dialect> getSupportedDialects();
 
     UUID getClientGuid();
+    
+    /**
+     * enforces message signing.  When message signing is enforced a received message that is not signed properly
+     * will be dropped.
+     */
+    boolean isStrictSigning();
 }

--- a/src/main/java/com/hierynomus/smbj/ConfigImpl.java
+++ b/src/main/java/com/hierynomus/smbj/ConfigImpl.java
@@ -26,6 +26,7 @@ public class ConfigImpl implements Config {
     protected EnumSet<SMB2Dialect> dialects;
     protected Random random;
     protected UUID clientGuid;
+    protected boolean isStrictSigning;
 
     @Override
     public Random getRandomProvider() {
@@ -40,5 +41,10 @@ public class ConfigImpl implements Config {
     @Override
     public UUID getClientGuid() {
         return clientGuid;
+    }
+    
+    @Override
+    public boolean isStrictSigning() {
+        return isStrictSigning;
     }
 }

--- a/src/main/java/com/hierynomus/smbj/DefaultConfig.java
+++ b/src/main/java/com/hierynomus/smbj/DefaultConfig.java
@@ -27,5 +27,6 @@ public class DefaultConfig extends ConfigImpl {
         random = new SecureRandom();
         dialects = EnumSet.of(SMB2Dialect.SMB_2_1, SMB2Dialect.SMB_2_0_2);
         clientGuid = UUID.randomUUID();
+        isStrictSigning = false; //TODO change to true when we are more confident
     }
 }

--- a/src/main/java/com/hierynomus/smbj/SMBClient.java
+++ b/src/main/java/com/hierynomus/smbj/SMBClient.java
@@ -57,6 +57,16 @@ public class SMBClient {
         return getEstablishedOrConnect(hostname, DEFAULT_PORT);
     }
 
+    /**
+     * Connect to the host at <pre>hostname</pre> on the given port
+     * @param hostname The hostname to connect to.
+     * @param port The port to connect to
+     * @return An established connection.
+     * @throws IOException If the connection could not be established.
+     */
+    public Connection connect(String hostname, int port) throws IOException {
+        return getEstablishedOrConnect(hostname, port);
+    }
 
     private Connection getEstablishedOrConnect(String hostname, int port) throws IOException {
         synchronized (this) {

--- a/src/main/java/com/hierynomus/smbj/common/MessageSigning.java
+++ b/src/main/java/com/hierynomus/smbj/common/MessageSigning.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.smbj.common;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.hierynomus.mssmb2.SMB2Header;
+
+public class MessageSigning {
+
+    /**
+     * check that the signature field of the SMB message buffer is correct.
+     * 
+     * @param buffer
+     *            byte array containing the SMB message.
+     * @param len
+     *            message length. Note that the buffer array might contain more
+     *            bytes than the message length. The len parameter indicates how
+     *            many bytes of the buffer array are in the message.
+     * @param signingKey
+     *            the session's signing key.
+     * @return
+     */
+    public static boolean validateSignature(byte[] buffer, int len, byte[] signingKey) {
+        try {
+            byte[] signature = computeSignature(buffer, len, signingKey);
+
+            // are signatures identical?
+            for (int i = 0; i < SMB2Header.SIGNATURE_SIZE; i++) {
+                if (signature[i] != buffer[SMB2Header.SIGNATURE_OFFSET + i])
+                    return false;
+            }
+            return true;
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            return false; // cannot check signature?
+        }
+    }
+
+    /**
+     * sign a SMB message buffer
+     * 
+     * @param buffer
+     *            byte array containing the SMB message.
+     * @param len
+     *            message length. Note that the buffer array might contain more
+     *            bytes than the message length. The len parameter indicates how
+     *            many bytes of the buffer array are in the message.
+     * @param signingKey
+     *            the session's signing key.
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     */
+    public static void signBuffer(byte[] buffer, int len, byte[] signingKey) throws InvalidKeyException,
+                    NoSuchAlgorithmException {
+        byte[] signature = computeSignature(buffer, len, signingKey);
+        System.arraycopy(signature, 0, buffer, SMB2Header.SIGNATURE_OFFSET, 16);
+    }
+
+    /**
+     * compute the HMAC signature on a SMB buffer. The calculation is performed
+     * <i>as if the signature field is filled with zeros</i>.
+     * 
+     * @param buffer
+     *            byte array containing the SMB message.
+     * @param len
+     *            message length. Note that the buffer array might contain more
+     *            bytes than the message length. The len parameter indicates how
+     *            many bytes of the buffer array are in the message.
+     * @param signingKey
+     *            the session's signing key.
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     */
+    private static byte[] computeSignature(byte[] buffer, int len, byte[] signingKey) throws NoSuchAlgorithmException,
+                    InvalidKeyException {
+        if (len < SMB2Header.STRUCTURE_SIZE)
+            throw new IllegalArgumentException("Buffer must be longer than 64 bytes");
+        SecretKeySpec signingKeySpec = new SecretKeySpec(signingKey, MessageSigning.HMAC_SHA256_ALGORITHM);
+        Mac mac = Mac.getInstance(MessageSigning.HMAC_SHA256_ALGORITHM);
+        mac.init(signingKeySpec);
+        mac.update(buffer, 0, SMB2Header.SIGNATURE_OFFSET);
+        for (int i = 0; i < SMB2Header.SIGNATURE_SIZE; i++)
+            mac.update((byte) 0);
+        mac.update(buffer, SMB2Header.STRUCTURE_SIZE, len - SMB2Header.STRUCTURE_SIZE);
+        byte[] signature = mac.doFinal();
+        return signature;
+    }
+
+    public static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
+
+}

--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -254,7 +254,7 @@ public class Connection extends SocketClient implements AutoCloseable, PacketRec
                 session = connectionInfo.getPreauthSessionTable().find(packet.getHeader().getSessionId());
                 if (session == null) {
                     logger.warn("Illegal request, no session matching the sessionId: {}", packet.getHeader().getSessionId());
-                    //TODO: maybe tear down the connection?
+                    //TODO maybe tear down the connection?
                     return;
                 }
             }

--- a/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
+++ b/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
@@ -51,7 +51,7 @@ public class ConnectionInfo {
 
     // All SMB2 Dialect
     private SessionTable sessionTable = new SessionTable();
-    private List<Void> preauthSessionTable;
+    private SessionTable preauthSessionTable = new SessionTable();
     private OutstandingRequests outstandingRequests = new OutstandingRequests();
     private SequenceWindow sequenceWindow;
     private byte[] gssNegotiateToken;
@@ -99,6 +99,10 @@ public class ConnectionInfo {
         return sessionTable;
     }
 
+    public SessionTable getPreauthSessionTable() {
+        return preauthSessionTable;
+    }
+    
     public UUID getClientGuid() {
         return clientGuid;
     }

--- a/src/main/java/com/hierynomus/smbj/connection/SessionTable.java
+++ b/src/main/java/com/hierynomus/smbj/connection/SessionTable.java
@@ -48,7 +48,7 @@ public class SessionTable {
         }
     }
     
-    Session sessionClosed(Long id) {
+    public Session sessionClosed(Long id) {
         lock.lock();
         try {
             return lookup.remove(id);

--- a/src/main/java/com/hierynomus/smbj/connection/SessionTable.java
+++ b/src/main/java/com/hierynomus/smbj/connection/SessionTable.java
@@ -25,12 +25,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
-class SessionTable {
+public class SessionTable {
     private static final Logger logger = LoggerFactory.getLogger(SessionTable.class);
     private ReentrantLock lock = new ReentrantLock();
     private Map<Long, Session> lookup = new HashMap<>();
 
-    void registerSession(Long id, Session session) {
+    public void registerSession(Long id, Session session) {
         lock.lock();
         try {
             lookup.put(id, session);
@@ -39,6 +39,15 @@ class SessionTable {
         }
     }
 
+    Session find(Long id) {
+        lock.lock();
+        try {
+            return lookup.get(id);
+        } finally {
+            lock.unlock();
+        }
+    }
+    
     Session sessionClosed(Long id) {
         lock.lock();
         try {

--- a/src/main/java/com/hierynomus/smbj/session/Session.java
+++ b/src/main/java/com/hierynomus/smbj/session/Session.java
@@ -17,8 +17,13 @@ package com.hierynomus.smbj.session;
 
 import java.io.IOException;
 import java.util.concurrent.Future;
+
+import javax.crypto.spec.SecretKeySpec;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.hierynomus.mssmb2.SMB2Packet;
 import com.hierynomus.mssmb2.SMB2ShareCapabilities;
 import com.hierynomus.mssmb2.messages.SMB2Logoff;
 import com.hierynomus.mssmb2.messages.SMB2TreeConnectRequest;
@@ -43,18 +48,18 @@ public class Session implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(Session.class);
     long sessionId;
     
-    byte[] signingKey;
+    SecretKeySpec signingKeySpec;
     boolean signingRequired;
     
     private Connection connection;
     private SMBEventBus bus;
     private TreeConnectTable treeConnectTable = new TreeConnectTable();
 
-    public Session(long sessionId, Connection connection, SMBEventBus bus, byte[] signingKey) {
+    public Session(long sessionId, Connection connection) {
         this.sessionId = sessionId;
         this.connection = connection;
-        this.bus = bus;
-        this.signingKey = signingKey;
+        this.bus = null;
+        this.signingKeySpec = null;
         this.signingRequired = connection.getConnectionInfo().isRequireSigning();
         if (bus != null)
         bus.subscribe(this);
@@ -91,7 +96,7 @@ public class Session implements AutoCloseable {
         try {
             SMB2TreeConnectRequest smb2TreeConnectRequest = new SMB2TreeConnectRequest(connection.getNegotiatedProtocol().getDialect(), smbPath, sessionId);
             smb2TreeConnectRequest.getHeader().setCreditRequest(256);
-            Future<SMB2TreeConnectResponse> send = connection.send(smb2TreeConnectRequest, signingRequired?this.getSigningKey():null);
+            Future<SMB2TreeConnectResponse> send = this.send(smb2TreeConnectRequest);
             SMB2TreeConnectResponse response = Futures.get(send, TransportException.Wrapper);
             if (response.getHeader().getStatus().isError()) {
                 logger.debug(response.getHeader().toString());
@@ -137,21 +142,21 @@ public class Session implements AutoCloseable {
             }
         }
         SMB2Logoff logoff = new SMB2Logoff(connection.getNegotiatedProtocol().getDialect(), sessionId);
-        SMB2Logoff response = Futures.get(connection.<SMB2Logoff>send(logoff, signingRequired?signingKey:null), TransportException.Wrapper);
+        SMB2Logoff response = Futures.get(send(logoff), TransportException.Wrapper);
         if (!response.getHeader().getStatus().isSuccess()) {
             throw new SMBApiException(response.getHeader(), "Could not logoff session <<" + sessionId + ">>");
         }
         bus.publish(new SessionLoggedOff(sessionId));
     }
 
-    public boolean getSigningRequired() {
+    public boolean isSigningRequired() {
         return signingRequired;
     }
-    public void setSigningKey(byte[] signingKey) {
-        this.signingKey = signingKey;
+    public void setSigningKeySpec(SecretKeySpec signingKey) {
+        this.signingKeySpec = signingKey;
     }
-    public byte[] getSigningKey() {
-        return signingKey;
+    public SecretKeySpec getSigningKeySpec() {
+        return signingKeySpec;
     }
 
     @Override
@@ -161,6 +166,16 @@ public class Session implements AutoCloseable {
 
     public Connection getConnection() {
         return connection;
+    }
+    
+    /**
+     * send a packet.  The packet will be signed or not depending on the session's flags.
+     * @param packet SMBPacket to send
+     * @return a Future to be used to retrieve the response packet
+     * @throws TransportException
+     */
+    public <T extends SMB2Packet> Future<T> send(SMB2Packet packet) throws TransportException {
+        return connection.send(packet, isSigningRequired() ? signingKeySpec : null);
     }
 
     public void setBus(SMBEventBus bus) {

--- a/src/main/java/com/hierynomus/smbj/session/Session.java
+++ b/src/main/java/com/hierynomus/smbj/session/Session.java
@@ -142,7 +142,7 @@ public class Session implements AutoCloseable {
             }
         }
         SMB2Logoff logoff = new SMB2Logoff(connection.getNegotiatedProtocol().getDialect(), sessionId);
-        SMB2Logoff response = Futures.get(send(logoff), TransportException.Wrapper);
+        SMB2Logoff response = Futures.get(this.<SMB2Logoff>send(logoff), TransportException.Wrapper);
         if (!response.getHeader().getStatus().isSuccess()) {
             throw new SMBApiException(response.getHeader(), "Could not logoff session <<" + sessionId + ">>");
         }

--- a/src/main/java/com/hierynomus/smbj/share/Directory.java
+++ b/src/main/java/com/hierynomus/smbj/share/Directory.java
@@ -54,7 +54,7 @@ public class Directory extends DiskEntry {
                 // .FileDirectoryInformation,
                 EnumSet.of(SMB2QueryDirectoryRequest.SMB2QueryDirectoryFlags.SMB2_REOPEN),
                 0, null);
-        Future<SMB2QueryDirectoryResponse> qdFuture = connection.send(qdr);
+        Future<SMB2QueryDirectoryResponse> qdFuture = connection.send(qdr, session.getSigningRequired()?session.getSigningKey():null);
 
         SMB2QueryDirectoryResponse qdResp = Futures.get(qdFuture, TransportException.Wrapper);
 

--- a/src/main/java/com/hierynomus/smbj/share/Directory.java
+++ b/src/main/java/com/hierynomus/smbj/share/Directory.java
@@ -54,7 +54,7 @@ public class Directory extends DiskEntry {
                 // .FileDirectoryInformation,
                 EnumSet.of(SMB2QueryDirectoryRequest.SMB2QueryDirectoryFlags.SMB2_REOPEN),
                 0, null);
-        Future<SMB2QueryDirectoryResponse> qdFuture = connection.send(qdr, session.getSigningRequired()?session.getSigningKey():null);
+        Future<SMB2QueryDirectoryResponse> qdFuture = session.send(qdr);
 
         SMB2QueryDirectoryResponse qdResp = Futures.get(qdFuture, TransportException.Wrapper);
 

--- a/src/main/java/com/hierynomus/smbj/share/DiskShare.java
+++ b/src/main/java/com/hierynomus/smbj/share/DiskShare.java
@@ -318,7 +318,7 @@ public class DiskShare extends Share {
         Connection connection = session.getConnection();
 
         // TODO Use Compounding
-        Future<SMB2CreateResponse> sendFuture = connection.send(smb2CreateRequest, session.getSigningRequired()?session.getSigningKey():null);
+        Future<SMB2CreateResponse> sendFuture = session.send(smb2CreateRequest);
         SMB2CreateResponse response = Futures.get(sendFuture, TransportException.Wrapper);
 
         if (response.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
@@ -415,7 +415,7 @@ public class DiskShare extends Share {
             fileId, infoType,
             fileInformationClass, null, null, securityInfo);
         try {
-            Future<SMB2QueryInfoResponse> qiResponseFuture = connection.send(qreq, session.getSigningRequired()?session.getSigningKey():null);
+            Future<SMB2QueryInfoResponse> qiResponseFuture = session.send(qreq);
             SMB2QueryInfoResponse qresp = Futures.get(qiResponseFuture, SMBRuntimeException.Wrapper);
 
             if (qresp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {

--- a/src/main/java/com/hierynomus/smbj/share/DiskShare.java
+++ b/src/main/java/com/hierynomus/smbj/share/DiskShare.java
@@ -318,7 +318,7 @@ public class DiskShare extends Share {
         Connection connection = session.getConnection();
 
         // TODO Use Compounding
-        Future<SMB2CreateResponse> sendFuture = connection.send(smb2CreateRequest);
+        Future<SMB2CreateResponse> sendFuture = connection.send(smb2CreateRequest, session.getSigningRequired()?session.getSigningKey():null);
         SMB2CreateResponse response = Futures.get(sendFuture, TransportException.Wrapper);
 
         if (response.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
@@ -415,7 +415,7 @@ public class DiskShare extends Share {
             fileId, infoType,
             fileInformationClass, null, null, securityInfo);
         try {
-            Future<SMB2QueryInfoResponse> qiResponseFuture = connection.send(qreq);
+            Future<SMB2QueryInfoResponse> qiResponseFuture = connection.send(qreq, session.getSigningRequired()?session.getSigningKey():null);
             SMB2QueryInfoResponse qresp = Futures.get(qiResponseFuture, SMBRuntimeException.Wrapper);
 
             if (qresp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {

--- a/src/main/java/com/hierynomus/smbj/share/File.java
+++ b/src/main/java/com/hierynomus/smbj/share/File.java
@@ -52,7 +52,7 @@ public class File extends DiskEntry {
             logger.debug("Writing to {} from offset {}", this.fileName, provider.getOffset());
             SMB2WriteRequest wreq = new SMB2WriteRequest(connection.getNegotiatedProtocol().getDialect(), getFileId(),
                 session.getSessionId(), treeConnect.getTreeId(), provider, connection.getNegotiatedProtocol().getMaxWriteSize());
-            Future<SMB2WriteResponse> writeFuture = connection.send(wreq, session.getSigningRequired()?session.getSigningKey():null);
+            Future<SMB2WriteResponse> writeFuture = session.send(wreq);
             SMB2WriteResponse wresp = Futures.get(writeFuture, TransportException.Wrapper);
             if (wresp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
                 throw new SMBApiException(wresp.getHeader(), "Write failed for " + this);

--- a/src/main/java/com/hierynomus/smbj/share/File.java
+++ b/src/main/java/com/hierynomus/smbj/share/File.java
@@ -52,7 +52,7 @@ public class File extends DiskEntry {
             logger.debug("Writing to {} from offset {}", this.fileName, provider.getOffset());
             SMB2WriteRequest wreq = new SMB2WriteRequest(connection.getNegotiatedProtocol().getDialect(), getFileId(),
                 session.getSessionId(), treeConnect.getTreeId(), provider, connection.getNegotiatedProtocol().getMaxWriteSize());
-            Future<SMB2WriteResponse> writeFuture = connection.send(wreq);
+            Future<SMB2WriteResponse> writeFuture = connection.send(wreq, session.getSigningRequired()?session.getSigningKey():null);
             SMB2WriteResponse wresp = Futures.get(writeFuture, TransportException.Wrapper);
             if (wresp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
                 throw new SMBApiException(wresp.getHeader(), "Write failed for " + this);

--- a/src/main/java/com/hierynomus/smbj/share/FileInputStream.java
+++ b/src/main/java/com/hierynomus/smbj/share/FileInputStream.java
@@ -121,6 +121,6 @@ public class FileInputStream extends InputStream {
     private Future<SMB2ReadResponse> sendRequest() throws IOException {
         SMB2ReadRequest rreq = new SMB2ReadRequest(connection.getNegotiatedProtocol(), fileId,
             session.getSessionId(), treeConnect.getTreeId(), offset);
-        return connection.send(rreq, session.getSigningRequired()?session.getSigningKey():null);
+        return session.send(rreq);
     }
 }

--- a/src/main/java/com/hierynomus/smbj/share/FileInputStream.java
+++ b/src/main/java/com/hierynomus/smbj/share/FileInputStream.java
@@ -121,6 +121,6 @@ public class FileInputStream extends InputStream {
     private Future<SMB2ReadResponse> sendRequest() throws IOException {
         SMB2ReadRequest rreq = new SMB2ReadRequest(connection.getNegotiatedProtocol(), fileId,
             session.getSessionId(), treeConnect.getTreeId(), offset);
-        return connection.send(rreq);
+        return connection.send(rreq, session.getSigningRequired()?session.getSigningKey():null);
     }
 }

--- a/src/main/java/com/hierynomus/smbj/share/FileOutputStream.java
+++ b/src/main/java/com/hierynomus/smbj/share/FileOutputStream.java
@@ -98,7 +98,7 @@ public class FileOutputStream extends OutputStream {
     private void sendWriteRequest() throws TransportException {
         SMB2WriteRequest wreq = new SMB2WriteRequest(connection.getNegotiatedProtocol().getDialect(), fileId,
             session.getSessionId(), treeConnect.getTreeId(), provider, connection.getNegotiatedProtocol().getMaxWriteSize());
-        Future<SMB2WriteResponse> writeFuture = connection.send(wreq);
+        Future<SMB2WriteResponse> writeFuture = connection.send(wreq, session.getSigningRequired()?session.getSigningKey():null);
         SMB2WriteResponse wresp = Futures.get(writeFuture, TransportException.Wrapper);
         if (wresp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
             throw new SMBApiException(wresp.getHeader(), "Write failed for " + this);

--- a/src/main/java/com/hierynomus/smbj/share/FileOutputStream.java
+++ b/src/main/java/com/hierynomus/smbj/share/FileOutputStream.java
@@ -98,7 +98,7 @@ public class FileOutputStream extends OutputStream {
     private void sendWriteRequest() throws TransportException {
         SMB2WriteRequest wreq = new SMB2WriteRequest(connection.getNegotiatedProtocol().getDialect(), fileId,
             session.getSessionId(), treeConnect.getTreeId(), provider, connection.getNegotiatedProtocol().getMaxWriteSize());
-        Future<SMB2WriteResponse> writeFuture = connection.send(wreq, session.getSigningRequired()?session.getSigningKey():null);
+        Future<SMB2WriteResponse> writeFuture = session.send(wreq);
         SMB2WriteResponse wresp = Futures.get(writeFuture, TransportException.Wrapper);
         if (wresp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
             throw new SMBApiException(wresp.getHeader(), "Write failed for " + this);

--- a/src/main/java/com/hierynomus/smbj/share/Share.java
+++ b/src/main/java/com/hierynomus/smbj/share/Share.java
@@ -75,7 +75,6 @@ public class Share implements AutoCloseable {
         logger.info("open {},{}", path);
 
         Session session = treeConnect.getSession();
-        Connection connection = session.getConnection();
         SMB2CreateRequest cr = openFileRequest(
                 treeConnect, path, accessMask, shareAccess, fileAttributes, createDisposition, createOptions);
         try {

--- a/src/main/java/com/hierynomus/smbj/share/Share.java
+++ b/src/main/java/com/hierynomus/smbj/share/Share.java
@@ -79,7 +79,7 @@ public class Share implements AutoCloseable {
         SMB2CreateRequest cr = openFileRequest(
                 treeConnect, path, accessMask, shareAccess, fileAttributes, createDisposition, createOptions);
         try {
-            Future<SMB2CreateResponse> responseFuture = connection.send(cr, (session.getSigningRequired()?session.getSigningKey():null));
+            Future<SMB2CreateResponse> responseFuture = session.send(cr);
             SMB2CreateResponse cresponse = Futures.get(responseFuture, SMBRuntimeException.Wrapper);
             if (cresponse.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {
                 throw new SMBApiException(cresponse.getHeader(), "Create failed for " + path);
@@ -119,7 +119,7 @@ public class Share implements AutoCloseable {
         SMB2Close closeReq = new SMB2Close(
             connection.getNegotiatedProtocol().getDialect(),
             treeConnect.getSession().getSessionId(), treeConnect.getTreeId(), fileId);
-        Future<SMB2Close> closeFuture = connection.send(closeReq, session.getSigningRequired()?session.getSigningKey():null);
+        Future<SMB2Close> closeFuture = session.send(closeReq);
         SMB2Close closeResp = Futures.get(closeFuture, TransportException.Wrapper);
 
         if (closeResp.getHeader().getStatus() != NtStatus.STATUS_SUCCESS) {

--- a/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
+++ b/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
@@ -64,7 +64,7 @@ public class TreeConnect {
 
     void close(Share share) throws TransportException {
         SMB2TreeDisconnect disconnect = new SMB2TreeDisconnect(connection.getNegotiatedProtocol().getDialect(), session.getSessionId(), treeId);
-        Future<SMB2Packet> send = connection.send(disconnect, session.getSigningRequired()?session.getSigningKey():null);
+        Future<SMB2Packet> send = session.send(disconnect);
         SMB2Packet smb2Packet = Futures.get(send, TransportException.Wrapper);
         if (!smb2Packet.getHeader().getStatus().isSuccess()) {
             throw new SMBApiException(smb2Packet.getHeader(), "Error closing connection to " + smbPath);

--- a/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
+++ b/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
@@ -64,7 +64,7 @@ public class TreeConnect {
 
     void close(Share share) throws TransportException {
         SMB2TreeDisconnect disconnect = new SMB2TreeDisconnect(connection.getNegotiatedProtocol().getDialect(), session.getSessionId(), treeId);
-        Future<SMB2Packet> send = connection.send(disconnect);
+        Future<SMB2Packet> send = connection.send(disconnect, session.getSigningRequired()?session.getSigningKey():null);
         SMB2Packet smb2Packet = Futures.get(send, TransportException.Wrapper);
         if (!smb2Packet.getHeader().getStatus().isSuccess()) {
             throw new SMBApiException(smb2Packet.getHeader(), "Error closing connection to " + smbPath);

--- a/src/main/java/com/hierynomus/smbj/transport/BaseTransport.java
+++ b/src/main/java/com/hierynomus/smbj/transport/BaseTransport.java
@@ -92,9 +92,6 @@ public abstract class BaseTransport implements TransportLayer {
     protected abstract void doWrite(SMBBuffer packetData) throws IOException;
 
     
-    // [MS-SMB2] 3.1.4.1 Signing An Outgoing Message
-    // If Connection.Dialect is "2.0.2" or "2.1", the sender MUST compute a 32-byte hash using HMAC-SHA256 over the entire message, 
-    // beginning with the SMB2 Header from step 1, and using the key provided.
     public static void signBuffer(SMBBuffer buffer, SecretKeySpec signingKeySpec) throws InvalidKeyException, NoSuchAlgorithmException {
         MessageSigning.signBuffer(buffer.array(), buffer.available(), signingKeySpec);
     }

--- a/src/main/java/com/hierynomus/smbj/transport/TransportLayer.java
+++ b/src/main/java/com/hierynomus/smbj/transport/TransportLayer.java
@@ -42,4 +42,6 @@ public interface TransportLayer {
      * @return The sequence number of the packet.
      */
     void write(SMB2Packet packet) throws TransportException;
+    
+    void writeSigned(SMB2Packet packet, byte[] signingKey) throws TransportException;
 }

--- a/src/main/java/com/hierynomus/smbj/transport/TransportLayer.java
+++ b/src/main/java/com/hierynomus/smbj/transport/TransportLayer.java
@@ -20,6 +20,8 @@ import com.hierynomus.mssmb2.SMB2Packet;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javax.crypto.spec.SecretKeySpec;
+
 public interface TransportLayer {
 
     /**
@@ -43,5 +45,11 @@ public interface TransportLayer {
      */
     void write(SMB2Packet packet) throws TransportException;
     
-    void writeSigned(SMB2Packet packet, byte[] signingKey) throws TransportException;
+    /**
+     * Write the packet to the transport, signed using the given signing key.
+     * @param packet The packet to write.
+     * @param signingKeySpec a SecretKeySpec to use while signing.  If null, no signing should be done.
+     * @return The sequence number of the packet.
+     */
+    void writeSigned(SMB2Packet packet, SecretKeySpec signingKeySpec) throws TransportException;
 }


### PR DESCRIPTION
Implement SMBv2 message signing. We extract the signing key from the NTLM authentication, perform proper keyexchange with the server, and sign most messages sent to the server. We also check signature of incoming messages, if the Connection requires it.

Make Connection output Buffered, so that when we write to the connection, a whole packet is written all at once.  This makes it much easier to use a protocol analyzer.  Previously, a lot of the time a packet would be broken up.

I've tested this very lightly against a Windows 2012 server.