### PR TITLE
Use custom FileTime instead of Date to avoid losing precision

### DIFF
--- a/src/main/java/com/hierynomus/msdtyp/FileTime.java
+++ b/src/main/java/com/hierynomus/msdtyp/FileTime.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hierynomus.msdtyp;
 
 import java.util.Date;
@@ -5,8 +20,7 @@ import java.util.Date;
 import static com.hierynomus.msdtyp.MsDataTypes.NANO100_TO_MILLI;
 import static com.hierynomus.msdtyp.MsDataTypes.WINDOWS_TO_UNIX_EPOCH;
 
-public class FileTime
-{
+public class FileTime {
     private final long windowsTimeStamp;
 
     public static FileTime fromDate(Date date) {
@@ -21,18 +35,15 @@ public class FileTime
         return new FileTime(epochMillis * NANO100_TO_MILLI + WINDOWS_TO_UNIX_EPOCH);
     }
 
-    public FileTime(long windowsTimeStamp)
-    {
+    public FileTime(long windowsTimeStamp) {
         this.windowsTimeStamp = windowsTimeStamp;
     }
 
-    public long getWindowsTimeStamp()
-    {
+    public long getWindowsTimeStamp() {
         return windowsTimeStamp;
     }
 
-    public long toEpochMillis()
-    {
+    public long toEpochMillis() {
         return (windowsTimeStamp - WINDOWS_TO_UNIX_EPOCH) / NANO100_TO_MILLI;
     }
 
@@ -41,8 +52,7 @@ public class FileTime
     }
 
     @Override
-    public boolean equals(Object o)
-    {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -52,8 +62,7 @@ public class FileTime
     }
 
     @Override
-    public int hashCode()
-    {
+    public int hashCode() {
         return (int) (windowsTimeStamp ^ (windowsTimeStamp >>> 32));
     }
 }

--- a/src/main/java/com/hierynomus/msdtyp/FileTime.java
+++ b/src/main/java/com/hierynomus/msdtyp/FileTime.java
@@ -1,0 +1,59 @@
+package com.hierynomus.msdtyp;
+
+import java.util.Date;
+
+import static com.hierynomus.msdtyp.MsDataTypes.NANO100_TO_MILLI;
+import static com.hierynomus.msdtyp.MsDataTypes.WINDOWS_TO_UNIX_EPOCH;
+
+public class FileTime
+{
+    private final long windowsTimeStamp;
+
+    public static FileTime fromDate(Date date) {
+        return new FileTime(date.getTime() * NANO100_TO_MILLI + WINDOWS_TO_UNIX_EPOCH);
+    }
+
+    public static FileTime now() {
+        return ofEpochMillis(System.currentTimeMillis());
+    }
+
+    public static FileTime ofEpochMillis(long epochMillis) {
+        return new FileTime(epochMillis * NANO100_TO_MILLI + WINDOWS_TO_UNIX_EPOCH);
+    }
+
+    public FileTime(long windowsTimeStamp)
+    {
+        this.windowsTimeStamp = windowsTimeStamp;
+    }
+
+    public long getWindowsTimeStamp()
+    {
+        return windowsTimeStamp;
+    }
+
+    public long toEpochMillis()
+    {
+        return (windowsTimeStamp - WINDOWS_TO_UNIX_EPOCH) / NANO100_TO_MILLI;
+    }
+
+    public Date toDate() {
+        return new Date(toEpochMillis());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FileTime fileTime = (FileTime) o;
+
+        return windowsTimeStamp == fileTime.windowsTimeStamp;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (windowsTimeStamp ^ (windowsTimeStamp >>> 32));
+    }
+}

--- a/src/main/java/com/hierynomus/msdtyp/MsDataTypes.java
+++ b/src/main/java/com/hierynomus/msdtyp/MsDataTypes.java
@@ -74,11 +74,11 @@ public class MsDataTypes {
      * @return a Date converted from the Windows FILETIME stored in the buffer
      * @throws Buffer.BufferException If an underflow occurs by reading the FILETIME (less than 8 bytes available).
      */
-    public static Date readFileTime(Buffer<?> buffer) throws Buffer.BufferException {
+    public static FileTime readFileTime(Buffer<?> buffer) throws Buffer.BufferException {
         long lowOrder = buffer.readUInt32();
         long highOrder = buffer.readUInt32();
         long windowsTimeStamp = (highOrder << 32) | lowOrder;
-        return new Date((windowsTimeStamp - WINDOWS_TO_UNIX_EPOCH) / NANO100_TO_MILLI);
+        return new FileTime(windowsTimeStamp);
     }
 
     /**

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileInfo.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileInfo.java
@@ -15,25 +15,24 @@
  */
 package com.hierynomus.msfscc.fileinformation;
 
+import com.hierynomus.msdtyp.FileTime;
 import com.hierynomus.msfscc.FileAttributes;
 import com.hierynomus.protocol.commons.EnumWithValue;
-
-import java.util.Date;
 
 public class FileInfo {
 
     private byte[] fileId; // This is not the SMB2FileId, but not sure what one can do with this id.
     private String fileName;
-    private final Date creationTime;
-    private final Date lastAccessTime;
-    private final Date lastWriteTime;
-    private final Date changeTime;
+    private final FileTime creationTime;
+    private final FileTime lastAccessTime;
+    private final FileTime lastWriteTime;
+    private final FileTime changeTime;
     private long fileAttributes;
     private long fileSize;
     private long accessMask;
 
 
-    FileInfo(String fileName, byte[] fileId, Date creationTime, Date lastAccessTime, Date lastWriteTime, Date changeTime, long fileAttributes, long fileSize, long accessMask) {
+    FileInfo(String fileName, byte[] fileId, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, FileTime changeTime, long fileAttributes, long fileSize, long accessMask) {
         this.fileName = fileName;
         this.fileId = fileId;
         this.creationTime = creationTime;
@@ -65,24 +64,20 @@ public class FileInfo {
         return accessMask;
     }
 
-    public Date getCreationTime() {
-        return copyOf(creationTime);
+    public FileTime getCreationTime() {
+        return creationTime;
     }
 
-    public Date getLastAccessTime() {
-        return copyOf(lastAccessTime);
+    public FileTime getLastAccessTime() {
+        return lastAccessTime;
     }
 
-    public Date getLastWriteTime() {
-        return copyOf(lastWriteTime);
+    public FileTime getLastWriteTime() {
+        return lastWriteTime;
     }
 
-    public Date getChangeTime() {
-        return copyOf(changeTime);
-    }
-
-    private Date copyOf(Date date) {
-        return date != null ? new Date(date.getTime()) : null;
+    public FileTime getChangeTime() {
+        return changeTime;
     }
 
     @Override

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
@@ -19,6 +19,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+
+import com.hierynomus.msdtyp.FileTime;
 import com.hierynomus.msdtyp.MsDataTypes;
 import com.hierynomus.msfscc.FileInformationClass;
 import com.hierynomus.protocol.commons.buffer.Buffer;
@@ -94,10 +96,10 @@ public class FileInformationFactory {
      */
     public static FileInfo parseFileAllInformation(Buffer.PlainBuffer buffer) throws Buffer.BufferException {
         // Basic Information
-        Date creationTime = MsDataTypes.readFileTime(buffer);
-        Date lastAccessTime = MsDataTypes.readFileTime(buffer);
-        Date lastWriteTime = MsDataTypes.readFileTime(buffer);
-        Date changeTime = MsDataTypes.readFileTime(buffer);
+        FileTime creationTime = MsDataTypes.readFileTime(buffer);
+        FileTime lastAccessTime = MsDataTypes.readFileTime(buffer);
+        FileTime lastWriteTime = MsDataTypes.readFileTime(buffer);
+        FileTime changeTime = MsDataTypes.readFileTime(buffer);
         long fileAttributes = buffer.readUInt32(); // File Attributes
         buffer.skip(4); // Reserved (4 bytes)
 
@@ -138,10 +140,10 @@ public class FileInformationFactory {
      * 2.4.17 FileIdBothDirectoryInformation
      */
     public static FileInfo parseFileIdBothDirectoryInformation(Buffer.PlainBuffer buffer) throws Buffer.BufferException {
-        Date creationTime = MsDataTypes.readFileTime(buffer);
-        Date lastAccessTime = MsDataTypes.readFileTime(buffer);
-        Date lastWriteTime = MsDataTypes.readFileTime(buffer);
-        Date changeTime = MsDataTypes.readFileTime(buffer);
+        FileTime creationTime = MsDataTypes.readFileTime(buffer);
+        FileTime lastAccessTime = MsDataTypes.readFileTime(buffer);
+        FileTime lastWriteTime = MsDataTypes.readFileTime(buffer);
+        FileTime changeTime = MsDataTypes.readFileTime(buffer);
         long fileSize = buffer.readUInt64(); // EndOfFile - Ignored
         buffer.readRawBytes(8); // AllocationSize - Ignored
         long fileAttributes = buffer.readUInt32(); // File Attributes

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2Close.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2Close.java
@@ -16,6 +16,8 @@
 package com.hierynomus.mssmb2.messages;
 
 import java.util.Date;
+
+import com.hierynomus.msdtyp.FileTime;
 import com.hierynomus.msdtyp.MsDataTypes;
 import com.hierynomus.mserref.NtStatus;
 import com.hierynomus.mssmb2.SMB2Dialect;
@@ -31,10 +33,10 @@ import com.hierynomus.smbj.common.SMBBuffer;
 public class SMB2Close extends SMB2Packet {
 
     private SMB2FileId fileId;
-    private Date creationTime;
-    private Date lastAccessTime;
-    private Date lastWriteTime;
-    private Date changeTime;
+    private FileTime creationTime;
+    private FileTime lastAccessTime;
+    private FileTime lastWriteTime;
+    private FileTime changeTime;
     private long allocationSize;
     private long size;
     private byte[] fileAttributes;
@@ -72,20 +74,20 @@ public class SMB2Close extends SMB2Packet {
         }
     }
 
-    public Date getCreationTime() {
-        return copyOf(creationTime);
+    public FileTime getCreationTime() {
+        return creationTime;
     }
 
-    public Date getLastAccessTime() {
-        return copyOf(lastAccessTime);
+    public FileTime getLastAccessTime() {
+        return lastAccessTime;
     }
 
-    public Date getLastWriteTime() {
-        return copyOf(lastWriteTime);
+    public FileTime getLastWriteTime() {
+        return lastWriteTime;
     }
 
-    public Date getChangeTime() {
-        return copyOf(changeTime);
+    public FileTime getChangeTime() {
+        return changeTime;
     }
 
     public long getAllocationSize() {
@@ -102,9 +104,5 @@ public class SMB2Close extends SMB2Packet {
 
     public void setFileId(SMB2FileId fileId) {
         this.fileId = fileId;
-    }
-
-    private Date copyOf(Date date) {
-        return date != null ? new Date(date.getTime()) : null;
     }
 }

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2CreateResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2CreateResponse.java
@@ -17,6 +17,8 @@ package com.hierynomus.mssmb2.messages;
 
 import java.util.Date;
 import java.util.EnumSet;
+
+import com.hierynomus.msdtyp.FileTime;
 import com.hierynomus.msdtyp.MsDataTypes;
 import com.hierynomus.mserref.NtStatus;
 import com.hierynomus.msfscc.FileAttributes;
@@ -32,10 +34,10 @@ import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
  */
 public class SMB2CreateResponse extends SMB2Packet {
 
-    private Date creationTime;
-    private Date lastAccessTime;
-    private Date lastWriteTime;
-    private Date changeTime;
+    private FileTime creationTime;
+    private FileTime lastAccessTime;
+    private FileTime lastWriteTime;
+    private FileTime changeTime;
     private EnumSet<FileAttributes> fileAttributes;
     private SMB2FileId fileId;
 
@@ -66,20 +68,20 @@ public class SMB2CreateResponse extends SMB2Packet {
         }
     }
 
-    public Date getCreationTime() {
-        return copyOf(creationTime);
+    public FileTime getCreationTime() {
+        return creationTime;
     }
 
-    public Date getLastAccessTime() {
-        return copyOf(lastAccessTime);
+    public FileTime getLastAccessTime() {
+        return lastAccessTime;
     }
 
-    public Date getLastWriteTime() {
-        return copyOf(lastWriteTime);
+    public FileTime getLastWriteTime() {
+        return lastWriteTime;
     }
 
-    public Date getChangeTime() {
-        return copyOf(changeTime);
+    public FileTime getChangeTime() {
+        return changeTime;
     }
 
     public EnumSet<FileAttributes> getFileAttributes() {
@@ -89,9 +91,4 @@ public class SMB2CreateResponse extends SMB2Packet {
     public SMB2FileId getFileId() {
         return fileId;
     }
-
-    private Date copyOf(Date d) {
-        return d != null ? new Date(d.getTime()) : null;
-    }
-
 }

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2NegotiateResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2NegotiateResponse.java
@@ -17,6 +17,8 @@ package com.hierynomus.mssmb2.messages;
 
 import java.util.Date;
 import java.util.UUID;
+
+import com.hierynomus.msdtyp.FileTime;
 import com.hierynomus.msdtyp.MsDataTypes;
 import com.hierynomus.mssmb2.SMB2Dialect;
 import com.hierynomus.mssmb2.SMB2Packet;
@@ -35,8 +37,8 @@ public class SMB2NegotiateResponse extends SMB2Packet {
     private int maxTransactSize;
     private int maxReadSize;
     private int maxWriteSize;
-    private Date systemTime;
-    private Date serverStartTime;
+    private FileTime systemTime;
+    private FileTime serverStartTime;
     private byte[] gssToken;
 
     /**

--- a/src/test/groovy/com/hierynomus/mssmb2/messages/SMB2CreateResponseTest.groovy
+++ b/src/test/groovy/com/hierynomus/mssmb2/messages/SMB2CreateResponseTest.groovy
@@ -15,6 +15,7 @@
  */
 package com.hierynomus.mssmb2.messages
 
+import com.hierynomus.msdtyp.FileTime
 import com.hierynomus.mssmb2.messages.SMB2CreateResponse
 import com.hierynomus.smbj.common.SMBBuffer
 import spock.lang.Specification
@@ -33,7 +34,7 @@ class SMB2CreateResponseTest extends Specification {
         resp.read(new SMBBuffer(bytes1))
 
         then:
-        resp.getCreationTime() == new Date(1461446418426L)
+        resp.getCreationTime() == new FileTime(131059200184264554L)
         Arrays.equals(([0x03,0x00,0x00,0x00,0x10,0x00,0x00,0x00] as byte[]), resp.fileId.persistentHandle)
     }
 


### PR DESCRIPTION
Date only provides millisecond granularity while SMB (and most backing servers) support nanosecond granularity. Using a custom FileTime class avoids loss of information in the protocol implementation. This allows timestamps to be transferred between servers without loss of precision.