### PR TITLE
Stress Test Documentaion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,5 @@ The implementation is based on the following specifications:
 - https://msdn.microsoft.com/en-us/library/cc231987.aspx[[MS-FSCC\]: File System Control Codes]
 
 == Stress Test Tools
-Look at the following links for some tools to aid in stress testing your SMB implmentations:
-
-Stress Test File:https://github.com/NinjaChris16/smbj/blob/master/StressTests.md
+Look at the following documentation for some tools to aid in stress testing your SMB implmentations:
+https://github.com/NinjaChris16/smbj/blob/master/StressTests.md[Stress Tests]

--- a/README.adoc
+++ b/README.adoc
@@ -50,3 +50,7 @@ The implementation is based on the following specifications:
 - https://msdn.microsoft.com/en-us/library/cc231196.aspx[[MS-ERREF\]: Windows Error Codes]
 - https://msdn.microsoft.com/en-us/library/cc231987.aspx[[MS-FSCC\]: File System Control Codes]
 
+== Stress Test Tools
+Look at the following links for some tools to aid in stress testing your SMB implmentations:
+
+Stress Test File:https://github.com/NinjaChris16/smbj/blob/master/StressTests.md[Docs]

--- a/README.adoc
+++ b/README.adoc
@@ -52,4 +52,5 @@ The implementation is based on the following specifications:
 
 == Stress Test Tools
 Look at the following documentation for some tools to aid in stress testing your SMB implmentations:
+
 https://github.com/NinjaChris16/smbj/blob/master/StressTests.md[Stress Tests]

--- a/README.adoc
+++ b/README.adoc
@@ -53,4 +53,4 @@ The implementation is based on the following specifications:
 == Stress Test Tools
 Look at the following links for some tools to aid in stress testing your SMB implmentations:
 
-Stress Test File:https://github.com/NinjaChris16/smbj/blob/master/StressTests.md[Docs]
+Stress Test File:https://github.com/NinjaChris16/smbj/blob/master/StressTests.md

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,4 @@ The implementation is based on the following specifications:
 - https://msdn.microsoft.com/en-us/library/cc231987.aspx[[MS-FSCC\]: File System Control Codes]
 
 == Stress Test Tools
-Look at the following documentation for some tools to aid in stress testing your SMB implmentations:
-
-https://github.com/NinjaChris16/smbj/blob/master/StressTests.md[Stress Tests]
+https://github.com/NinjaChris16/smbj/blob/master/StressTests.md[Look at the following documentation for some tools to aid in stress testing your SMB implmentations]

--- a/StressTests.md
+++ b/StressTests.md
@@ -1,0 +1,25 @@
+# Stress Testing Tools for SMB
+
+## DBENCH
+DBENCH can be used to stress a filesystem or a server to see which workload it becomes saturated and can also be used for preditcion analysis to determine 
+"How many concurrent clients/applications performing this workload can my server handle before response starts to lag?" 
+
+### DBENCH Website: https://dbench.samba.org/web/index.html
+
+### Information on how to use Loadfiles with SMB: https://dbench.samba.org/web/smb-loadfiles.html
+
+## clumsy
+Application used to simulate high latency, low bandwidth, and packet loss on Windows systems. 
+Allows one to see how an application functions when network conditions are spotty.
+
+### clumsy Website: https://jagt.github.io/clumsy/
+
+### clumsy Manual: https://jagt.github.io/clumsy/manual.html
+
+
+== Stress Test Tools
+Look at the following links for some tools to aid in stress testing your SMB implmentations:
+
+
+
+link:index.html[Docs]

--- a/StressTests.md
+++ b/StressTests.md
@@ -11,6 +11,7 @@ https://dbench.samba.org/web/index.html
 https://dbench.samba.org/web/smb-loadfiles.html
 
 
+
 ## clumsy
 Application used to simulate high latency, low bandwidth, and packet loss on Windows systems. 
 Allows one to see how an application functions when network conditions are spotty.

--- a/StressTests.md
+++ b/StressTests.md
@@ -11,7 +11,6 @@ https://dbench.samba.org/web/index.html
 https://dbench.samba.org/web/smb-loadfiles.html
 
 
-
 ## clumsy
 Application used to simulate high latency, low bandwidth, and packet loss on Windows systems. 
 Allows one to see how an application functions when network conditions are spotty.
@@ -19,11 +18,3 @@ Allows one to see how an application functions when network conditions are spott
 ### clumsy Website: https://jagt.github.io/clumsy/
 
 ### clumsy Manual: https://jagt.github.io/clumsy/manual.html
-
-
-== Stress Test Tools
-Look at the following links for some tools to aid in stress testing your SMB implmentations:
-
-
-
-link:index.html[Docs]

--- a/StressTests.md
+++ b/StressTests.md
@@ -15,6 +15,8 @@ https://dbench.samba.org/web/smb-loadfiles.html
 Application used to simulate high latency, low bandwidth, and packet loss on Windows systems. 
 Allows one to see how an application functions when network conditions are spotty.
 
-### clumsy Website: https://jagt.github.io/clumsy/
+### clumsy Website: 
+https://jagt.github.io/clumsy/
 
-### clumsy Manual: https://jagt.github.io/clumsy/manual.html
+### clumsy Manual: 
+https://jagt.github.io/clumsy/manual.html

--- a/StressTests.md
+++ b/StressTests.md
@@ -10,6 +10,7 @@ https://dbench.samba.org/web/index.html
 ### Information on how to use Loadfiles with SMB: 
 https://dbench.samba.org/web/smb-loadfiles.html
 
+
 ## clumsy
 Application used to simulate high latency, low bandwidth, and packet loss on Windows systems. 
 Allows one to see how an application functions when network conditions are spotty.

--- a/StressTests.md
+++ b/StressTests.md
@@ -4,9 +4,11 @@
 DBENCH can be used to stress a filesystem or a server to see which workload it becomes saturated and can also be used for preditcion analysis to determine 
 "How many concurrent clients/applications performing this workload can my server handle before response starts to lag?" 
 
-### DBENCH Website: https://dbench.samba.org/web/index.html
+### DBENCH Website: 
+https://dbench.samba.org/web/index.html
 
-### Information on how to use Loadfiles with SMB: https://dbench.samba.org/web/smb-loadfiles.html
+### Information on how to use Loadfiles with SMB: 
+https://dbench.samba.org/web/smb-loadfiles.html
 
 ## clumsy
 Application used to simulate high latency, low bandwidth, and packet loss on Windows systems. 

--- a/src/it/java/SmbjTest.java
+++ b/src/it/java/SmbjTest.java
@@ -286,6 +286,7 @@ public class SmbjTest {
         return randomBytes;
     }
 
+    //Define Rpc?
     @Test
     public void testRpc() throws IOException, SMBApiException, URISyntaxException {
         logger.info("Connect {},{},{},{}", ci.host, ci.user, ci.domain, ci.sharePath);
@@ -401,14 +402,15 @@ public class SmbjTest {
     }
 
 
-    // Caution load whole files into memory
+    // Caution: load whole files into memory
     private void assertFileContent(String localResource, String downloadedFile)
             throws URISyntaxException, IOException {
         byte[] expectedBytes = Files.readAllBytes(Paths.get(this.getClass().getResource(localResource).toURI()));
         byte[] bytes = Files.readAllBytes(Paths.get(downloadedFile));
         assertArrayEquals(expectedBytes, bytes);
     }
-
+    
+    
     void write(DiskShare share, String remotePath, String localResource)
             throws IOException, SMBApiException {
         logger.debug("Writing {}, {} to {}", localResource, this.getClass().getResource(localResource), remotePath);


### PR DESCRIPTION
Added some information on stress test applications for SMB. The stress test file contains information on stress test applications and links to their websites/manuals. A link to the file was added to the bottom of the README. 