### PR TITLE
NamedPipe is now completely not usable - make it usable at least in a low-level way

### DIFF
--- a/src/main/java/com/hierynomus/smbj/share/NamedPipe.java
+++ b/src/main/java/com/hierynomus/smbj/share/NamedPipe.java
@@ -15,10 +15,22 @@
  */
 package com.hierynomus.smbj.share;
 
+import java.util.Set;
+
+import com.hierynomus.msdtyp.AccessMask;
+import com.hierynomus.msfscc.FileAttributes;
+import com.hierynomus.mssmb2.SMB2CreateDisposition;
+import com.hierynomus.mssmb2.SMB2CreateOptions;
+import com.hierynomus.mssmb2.SMB2FileId;
+import com.hierynomus.mssmb2.SMB2ShareAccess;
 import com.hierynomus.smbj.common.SmbPath;
 
 public class NamedPipe extends Share {
     public NamedPipe(SmbPath smbPath, TreeConnect treeConnect) {
         super(smbPath, treeConnect);
+    }
+
+    public SMB2FileId openFileId(String path, Set<AccessMask> accessMask, Set<FileAttributes> fileAttributes, Set<SMB2ShareAccess> shareAccess, SMB2CreateDisposition createDisposition, Set<SMB2CreateOptions> createOptions) {
+        return super.openFileId(path, accessMask, fileAttributes, shareAccess, createDisposition, createOptions);
     }
 }

--- a/src/main/java/com/hierynomus/smbj/share/NamedPipe.java
+++ b/src/main/java/com/hierynomus/smbj/share/NamedPipe.java
@@ -23,6 +23,7 @@ import com.hierynomus.mssmb2.SMB2CreateDisposition;
 import com.hierynomus.mssmb2.SMB2CreateOptions;
 import com.hierynomus.mssmb2.SMB2FileId;
 import com.hierynomus.mssmb2.SMB2ShareAccess;
+import com.hierynomus.smbj.common.SMBApiException;
 import com.hierynomus.smbj.common.SmbPath;
 
 public class NamedPipe extends Share {
@@ -32,5 +33,9 @@ public class NamedPipe extends Share {
 
     public SMB2FileId openFileId(String path, Set<AccessMask> accessMask, Set<FileAttributes> fileAttributes, Set<SMB2ShareAccess> shareAccess, SMB2CreateDisposition createDisposition, Set<SMB2CreateOptions> createOptions) {
         return super.openFileId(path, accessMask, fileAttributes, shareAccess, createDisposition, createOptions);
+    }
+
+    void closeFileId(SMB2FileId fileId) throws SMBApiException {
+        super.closeFileId(fileId);
     }
 }

--- a/src/main/java/com/hierynomus/smbj/share/NamedPipe.java
+++ b/src/main/java/com/hierynomus/smbj/share/NamedPipe.java
@@ -35,7 +35,7 @@ public class NamedPipe extends Share {
         return super.openFileId(path, accessMask, fileAttributes, shareAccess, createDisposition, createOptions);
     }
 
-    void closeFileId(SMB2FileId fileId) throws SMBApiException {
+    public void closeFileId(SMB2FileId fileId) throws SMBApiException {
         super.closeFileId(fileId);
     }
 }


### PR DESCRIPTION
In a recent code change, the open() method of Share has become protected. As a result, there is absolutely nothing that can be done with a NamedPipe object.
This breaks existing code that was built on top of NamedPipe, using Share.open().

Eventually, there sould be an open() method in NamedPipe that would return a proper remote object, similar to DiskShare.open(). But until a full implementation of a named pipe is available, there needs to be at least a low-level way of opening a handle on it.

So I added an openFileId() method to NamedPipe, which simply delegates to the super class.