### PR TITLE
skip "." and ".." on recursive rmdir().

### DIFF
--- a/src/main/java/com/hierynomus/smbj/share/DiskShare.java
+++ b/src/main/java/com/hierynomus/smbj/share/DiskShare.java
@@ -275,6 +275,9 @@ public class DiskShare extends Share {
         if (recursive) {
             List<FileIdBothDirectoryInformation> list = list(path);
             for (FileIdBothDirectoryInformation fi : list) {
+	            if (fi.getFileName().equals(".") || fi.getFileName().equals("..")) {
+		            continue;
+	            }
                 String childPath = path + "\\" + fi.getFileName();
                 if (!EnumWithValue.EnumUtils.isSet(fi.getFileAttributes(), FILE_ATTRIBUTE_DIRECTORY)) {
                     rm(childPath);


### PR DESCRIPTION
fixed 'Recursive DiskShare.rmdir() raise StackOverflowError. #97 '