### PR TITLE
Rename Config to SmbConfig and expose SocketFactory in Config

### DIFF
--- a/src/main/java/com/hierynomus/protocol/commons/socket/SocketClient.java
+++ b/src/main/java/com/hierynomus/protocol/commons/socket/SocketClient.java
@@ -32,13 +32,14 @@ public abstract class SocketClient {
     private InputStream input;
     private OutputStream output;
 
-    private SocketFactory socketFactory = new ProxySocketFactory();
+    private SocketFactory socketFactory;
 
     private int soTimeout = 0;
 
-    public SocketClient(int defaultPort, int soTimeout) {
+    public SocketClient(int defaultPort, int soTimeout, SocketFactory socketFactory) {
         this.defaultPort = defaultPort;
         this.soTimeout = soTimeout;
+        this.socketFactory = socketFactory;
     }
 
     public void connect(String hostname, int port) throws IOException {
@@ -86,14 +87,6 @@ public abstract class SocketClient {
 
     public boolean isConnected() {
         return (socket != null) && socket.isConnected();
-    }
-
-    public void setSocketFactory(SocketFactory factory) {
-        if (factory == null) {
-            socketFactory = new ProxySocketFactory();
-        } else {
-            socketFactory = factory;
-        }
     }
 
     public Socket getSocket() {

--- a/src/main/java/com/hierynomus/smbj/SMBClient.java
+++ b/src/main/java/com/hierynomus/smbj/SMBClient.java
@@ -33,15 +33,15 @@ public class SMBClient {
 
     private Map<String, Connection> connectionTable = new ConcurrentHashMap<>();
 
-    private Config config;
+    private SmbConfig config;
 
     private SMBEventBus bus;
 
     public SMBClient() {
-        this(Config.createDefaultConfig());
+        this(SmbConfig.createDefaultConfig());
     }
 
-    public SMBClient(Config config) {
+    public SMBClient(SmbConfig config) {
         this.config = config;
         bus = new SMBEventBus();
     }

--- a/src/main/java/com/hierynomus/smbj/SmbConfig.java
+++ b/src/main/java/com/hierynomus/smbj/SmbConfig.java
@@ -177,7 +177,7 @@ public final class SmbConfig {
 
         public Builder withSocketFactory(SocketFactory socketFactory) {
             if (socketFactory == null) {
-                throw new IllegalArgumentException("Cannot set a null SocketFactory");
+                throw new IllegalArgumentException("Socket factory may not be null");
             }
             config.socketFactory = socketFactory;
             return this;

--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -27,7 +27,7 @@ import com.hierynomus.mssmb2.messages.SMB2SessionSetup;
 import com.hierynomus.protocol.commons.Factory;
 import com.hierynomus.protocol.commons.concurrent.Futures;
 import com.hierynomus.protocol.commons.socket.SocketClient;
-import com.hierynomus.smbj.Config;
+import com.hierynomus.smbj.SmbConfig;
 import com.hierynomus.smbj.auth.AuthenticationContext;
 import com.hierynomus.smbj.auth.Authenticator;
 import com.hierynomus.smbj.common.SMBApiException;
@@ -67,18 +67,18 @@ public class Connection extends SocketClient implements AutoCloseable, PacketRec
     private static final Logger logger = LoggerFactory.getLogger(Connection.class);
     private ConnectionInfo connectionInfo;
 
-    private Config config;
+    private SmbConfig config;
     private TransportLayer<SMB2Packet> transport;
     private final SMBEventBus bus;
     private PacketReader<SMB2Packet> packetReader;
     private final ReentrantLock lock = new ReentrantLock();
 
-    public Connection(Config config, SMBEventBus bus) {
+    public Connection(SmbConfig config, SMBEventBus bus) {
         this(config, new DirectTcpTransport<SMB2Packet>(), bus);
     }
 
-    private Connection(Config config, TransportLayer<SMB2Packet> transport, SMBEventBus bus) {
-        super(transport.getDefaultPort(), config.getSoTimeout());
+    private Connection(SmbConfig config, TransportLayer<SMB2Packet> transport, SMBEventBus bus) {
+        super(transport.getDefaultPort(), config.getSoTimeout(), config.getSocketFactory());
         this.config = config;
         this.transport = transport;
         this.bus = bus;
@@ -114,7 +114,7 @@ public class Connection extends SocketClient implements AutoCloseable, PacketRec
         super.disconnect();
     }
 
-    public Config getConfig() {
+    public SmbConfig getConfig() {
         return config;
     }
 

--- a/src/main/java/com/hierynomus/smbj/share/Share.java
+++ b/src/main/java/com/hierynomus/smbj/share/Share.java
@@ -24,7 +24,7 @@ import com.hierynomus.msfscc.FileSystemInformationClass;
 import com.hierynomus.mssmb2.*;
 import com.hierynomus.mssmb2.messages.*;
 import com.hierynomus.protocol.commons.concurrent.Futures;
-import com.hierynomus.smbj.Config;
+import com.hierynomus.smbj.SmbConfig;
 import com.hierynomus.smbj.common.SMBApiException;
 import com.hierynomus.smbj.common.SMBRuntimeException;
 import com.hierynomus.smbj.common.SmbPath;
@@ -62,7 +62,7 @@ public class Share implements AutoCloseable {
         Connection connection = treeConnect.getConnection();
         NegotiatedProtocol negotiatedProtocol = connection.getNegotiatedProtocol();
         dialect = negotiatedProtocol.getDialect();
-        Config config = connection.getConfig();
+        SmbConfig config = connection.getConfig();
         readBufferSize = Math.min(config.getReadBufferSize(), negotiatedProtocol.getMaxReadSize());
         writeBufferSize = Math.min(config.getWriteBufferSize(), negotiatedProtocol.getMaxWriteSize());
         transactBufferSize = Math.min(config.getTransactBufferSize(), negotiatedProtocol.getMaxTransactSize());


### PR DESCRIPTION
The class is renamed because `Config` is very generic and used by a lot of libraries. It prevents needing to fully qualify the classname in case of conflict.

Also this exposes the SocketFactory which allows you to more specifically tweak the Sockets if needed. We still retain the `soTimeout`setting as you can set that without the need to tweak the entire `SocketFactory`, which makes for an overall better experience.