### PR TITLE
Issue #138 Remove the mbassador library warning messages from log

### DIFF
--- a/src/main/java/com/hierynomus/smbj/event/SMBEventBus.java
+++ b/src/main/java/com/hierynomus/smbj/event/SMBEventBus.java
@@ -17,17 +17,17 @@ package com.hierynomus.smbj.event;
 
 import net.engio.mbassy.bus.SyncMessageBus;
 import net.engio.mbassy.bus.common.PubSubSupport;
+import net.engio.mbassy.bus.error.IPublicationErrorHandler;
 
 /**
- * Our own delegating class to wrap the MBassador event bus. This ensures that we only need to use their annotations
- * throughout the codebase, and can easily switch it out if need be.
+ * Our own delegating class to wrap the MBassador event bus. This ensures that we only need to use their annotations throughout the codebase, and can easily switch it out if need be.
  */
 public class SMBEventBus {
 
     private PubSubSupport<SMBEvent> wrappedBus;
 
     public SMBEventBus() {
-        this(new SyncMessageBus<SMBEvent>());
+        this(new SyncMessageBus<SMBEvent>(new IPublicationErrorHandler.ConsoleLogger()));
     }
 
     public SMBEventBus(PubSubSupport<SMBEvent> wrappedBus) {


### PR DESCRIPTION
Constructor changed to pass Error Handler, expected since mbassador  version 1.1.7