### PR TITLE
Implementation for file setLength (truncate file)

### DIFF
--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileEndOfFileInformation.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileEndOfFileInformation.java
@@ -19,7 +19,10 @@ public class FileEndOfFileInformation implements FileSettableInformation {
 
     private long endOfFile;
 
-    public FileEndOfFileInformation(long endOfFile) {
+    public FileEndOfFileInformation(long endOfFile) throws IllegalArgumentException {
+        if(endOfFile < 0L) {
+            throw new IllegalArgumentException("endOfFile MUST be greater than or equal to 0");
+        }
         this.endOfFile = endOfFile;
     }
 

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileEndOfFileInformation.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileEndOfFileInformation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.msfscc.fileinformation;
+
+public class FileEndOfFileInformation implements FileSettableInformation {
+
+    private long endOfFile;
+
+    public FileEndOfFileInformation(long endOfFile) {
+        this.endOfFile = endOfFile;
+    }
+
+    public long getEndOfFile() {
+        return endOfFile;
+    }
+}

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
@@ -132,6 +132,19 @@ public class FileInformationFactory {
             }
         });
 
+        FileInformation.Encoder<FileEndOfFileInformation> endOfFileCodec = new FileInformation.Encoder<FileEndOfFileInformation>() {
+            @Override
+            public FileInformationClass getInformationClass() {
+                return FileInformationClass.FileEndOfFileInformation;
+            }
+
+            @Override
+            public void write(FileEndOfFileInformation info, Buffer outputBuffer) {
+                writeFileEndOfFileInformation(info, outputBuffer);
+            }
+        };
+        encoders.put(FileEndOfFileInformation.class, endOfFileCodec);
+
         decoders.put(FileInternalInformation.class, new FileInformation.Decoder<FileInternalInformation>() {
             @Override
             public FileInformationClass getInformationClass() {
@@ -460,6 +473,13 @@ public class FileInformationFactory {
     private static FileEaInformation parseFileEaInformation(Buffer<?> buffer) throws Buffer.BufferException {
         long eaSize = buffer.readUInt32();
         return new FileEaInformation(eaSize);
+    }
+
+    /**
+     * [MS-FSCC] 2.4.13 FileEndOfFileInformation
+     */
+    private static void writeFileEndOfFileInformation(FileEndOfFileInformation information, Buffer<?> buffer) {
+        buffer.putLong(information.getEndOfFile());
     }
 
     private static FileAccessInformation parseFileAccessInformation(Buffer<?> buffer) throws Buffer.BufferException {

--- a/src/main/java/com/hierynomus/smbj/share/File.java
+++ b/src/main/java/com/hierynomus/smbj/share/File.java
@@ -156,8 +156,12 @@ public class File extends DiskEntry {
      * @throws SMBApiException
      */
     public void setLength(long endOfFile) throws SMBApiException {
-        FileEndOfFileInformation endOfFileInfo = new FileEndOfFileInformation(endOfFile);
-        this.setFileInformation(endOfFileInfo);
+        try {
+            FileEndOfFileInformation endOfFileInfo = new FileEndOfFileInformation(endOfFile);
+            this.setFileInformation(endOfFileInfo);
+        } catch (IllegalArgumentException iae) {
+            logger.warn("setLength : " + iae);
+        }
     }
 
     public InputStream getInputStream() {

--- a/src/main/java/com/hierynomus/smbj/share/File.java
+++ b/src/main/java/com/hierynomus/smbj/share/File.java
@@ -17,8 +17,10 @@ package com.hierynomus.smbj.share;
 
 import com.hierynomus.mserref.NtStatus;
 import com.hierynomus.mssmb2.SMB2FileId;
+import com.hierynomus.msfscc.fileinformation.FileEndOfFileInformation;
 import com.hierynomus.mssmb2.messages.SMB2ReadResponse;
 import com.hierynomus.mssmb2.messages.SMB2WriteResponse;
+import com.hierynomus.smbj.common.SMBApiException;
 import com.hierynomus.smbj.ProgressListener;
 import com.hierynomus.smbj.io.ArrayByteChunkProvider;
 import com.hierynomus.smbj.io.ByteChunkProvider;
@@ -146,6 +148,16 @@ public class File extends DiskEntry {
             destStream.write(buf, 0, numRead);
         }
         is.close();
+    }
+
+    /***
+     * The function for truncate or set file length for a file
+     * @param endOfFile 64-bit signed integer in bytes, MUST be greater than or equal to 0
+     * @throws SMBApiException
+     */
+    public void setLength(long endOfFile) throws SMBApiException {
+        FileEndOfFileInformation endOfFileInfo = new FileEndOfFileInformation(endOfFile);
+        this.setFileInformation(endOfFileInfo);
     }
 
     public InputStream getInputStream() {

--- a/src/main/java/com/hierynomus/smbj/share/File.java
+++ b/src/main/java/com/hierynomus/smbj/share/File.java
@@ -156,12 +156,8 @@ public class File extends DiskEntry {
      * @throws SMBApiException
      */
     public void setLength(long endOfFile) throws SMBApiException {
-        try {
-            FileEndOfFileInformation endOfFileInfo = new FileEndOfFileInformation(endOfFile);
-            this.setFileInformation(endOfFileInfo);
-        } catch (IllegalArgumentException iae) {
-            logger.warn("setLength : " + iae);
-        }
+        FileEndOfFileInformation endOfFileInfo = new FileEndOfFileInformation(endOfFile);
+        this.setFileInformation(endOfFileInfo);
     }
 
     public InputStream getInputStream() {


### PR DESCRIPTION
Implementing the setLength function for file. When writing a large file, setLength before actual writing the file would improve the performance. Also can be used for truncating the files.