### PR TITLE
Provide session setup flags negotiated in SMB2SessionSetup to the Session

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -155,6 +155,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
             SMB2SessionSetup receive = authenticationRound(authenticator, authContext, connectionInfo.getGssNegotiateToken(), session);
             long sessionId = receive.getHeader().getSessionId();
             session.setSessionId(sessionId);
+            session.setSessionFlags(receive.getSessionFlags());
             connectionInfo.getPreauthSessionTable().registerSession(sessionId, session);
             try {
                 while (receive.getHeader().getStatus() == NtStatus.STATUS_MORE_PROCESSING_REQUIRED) {

--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -155,7 +155,6 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
             SMB2SessionSetup receive = authenticationRound(authenticator, authContext, connectionInfo.getGssNegotiateToken(), session);
             long sessionId = receive.getHeader().getSessionId();
             session.setSessionId(sessionId);
-            session.setSessionFlags(receive.getSessionFlags());
             connectionInfo.getPreauthSessionTable().registerSession(sessionId, session);
             try {
                 while (receive.getHeader().getStatus() == NtStatus.STATUS_MORE_PROCESSING_REQUIRED) {
@@ -171,6 +170,8 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
                     // process the last received buffer
                     authenticator.authenticate(authContext, receive.getSecurityBuffer(), session);
                 }
+                session.setSessionFlags(receive.getSessionFlags());
+
                 logger.info("Successfully authenticated {} on {}, session is {}", authContext.getUsername(), remoteName, session.getSessionId());
                 connectionInfo.getSessionTable().registerSession(session.getSessionId(), session);
                 return session;

--- a/src/main/java/com/hierynomus/smbj/session/Session.java
+++ b/src/main/java/com/hierynomus/smbj/session/Session.java
@@ -20,6 +20,7 @@ import com.hierynomus.mssmb2.SMB2ShareCapabilities;
 import com.hierynomus.mssmb2.SMBApiException;
 import com.hierynomus.mssmb2.messages.SMB2CreateRequest;
 import com.hierynomus.mssmb2.messages.SMB2Logoff;
+import com.hierynomus.mssmb2.messages.SMB2SessionSetup;
 import com.hierynomus.mssmb2.messages.SMB2TreeConnectRequest;
 import com.hierynomus.mssmb2.messages.SMB2TreeConnectResponse;
 import com.hierynomus.protocol.commons.concurrent.Futures;
@@ -38,6 +39,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -50,6 +53,7 @@ public class Session implements AutoCloseable {
 
     private PacketSignatory packetSignatory;
     private boolean serverSigningRequired;
+    private Set<SMB2SessionSetup.SMB2SessionFlags> sessionFlags;
 
     private Connection connection;
     private SMBEventBus bus;
@@ -68,6 +72,7 @@ public class Session implements AutoCloseable {
         if (bus != null) {
             bus.subscribe(this);
         }
+        this.sessionFlags = Collections.emptySet();
     }
 
     public long getSessionId() {
@@ -210,5 +215,13 @@ public class Session implements AutoCloseable {
 
     public PacketSignatory getPacketSignatory() {
         return packetSignatory;
+    }
+
+    public Set<SMB2SessionSetup.SMB2SessionFlags> getSessionFlags() {
+        return sessionFlags;
+    }
+
+    public void setSessionFlags(Set<SMB2SessionSetup.SMB2SessionFlags> sessionFlags) {
+        this.sessionFlags = sessionFlags;
     }
 }

--- a/src/main/java/com/hierynomus/smbj/session/Session.java
+++ b/src/main/java/com/hierynomus/smbj/session/Session.java
@@ -69,10 +69,10 @@ public class Session implements AutoCloseable {
         this.dfsEnabled = dfsEnabled;
         this.packetSignatory = new PacketSignatory(connection.getNegotiatedProtocol().getDialect(), securityProvider);
         this.serverSigningRequired = signingRequired;
+        this.sessionFlags = Collections.emptySet();
         if (bus != null) {
             bus.subscribe(this);
         }
-        this.sessionFlags = Collections.emptySet();
     }
 
     public long getSessionId() {


### PR DESCRIPTION
It does require a dependency on `SMB2SessionSetup.SMB2SessionFlags`, but allows us to get more information about the `Session`, such as whether or not it is a guest.