### PR TITLE
Exposing WindowsVersion as a part of NTLM connection setup

### DIFF
--- a/src/main/java/com/hierynomus/ntlm/messages/NtlmChallenge.java
+++ b/src/main/java/com/hierynomus/ntlm/messages/NtlmChallenge.java
@@ -152,4 +152,6 @@ public class NtlmChallenge extends NtlmPacket {
     public Object getAvPairObject(AvId key) {
         return this.targetInfo.get(key);
     }
+
+    public WindowsVersion getVersion() { return version; }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
@@ -46,6 +46,7 @@ public class NtlmAuthenticator implements Authenticator {
     private static final ASN1ObjectIdentifier NTLMSSP = MicrosoftObjectIdentifiers.microsoft.branch("2.2.10");
     private SecurityProvider securityProvider;
     private Random random;
+    private WindowsVersion version;
 
     public static class Factory implements com.hierynomus.protocol.commons.Factory.Named<Authenticator> {
         @Override
@@ -85,6 +86,7 @@ public class NtlmAuthenticator implements Authenticator {
                     throw new IOException(e);
                 }
                 logger.debug("Received NTLM challenge from: {}", challenge.getTargetName());
+                version = challenge.getVersion();
 
                 byte[] serverChallenge = challenge.getServerChallenge();
                 byte[] responseKeyNT = ntlmFunctions.NTOWFv2(String.valueOf(context.getPassword()), context.getUsername(), context.getDomain());
@@ -177,4 +179,5 @@ public class NtlmAuthenticator implements Authenticator {
         return context.getClass().equals(AuthenticationContext.class);
     }
 
+    public WindowsVersion getVersion() { return version; }
 }

--- a/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
+++ b/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
@@ -88,6 +88,10 @@ class ConnectionInfo {
         return (serverSecurityMode & 0x02) > 0;
     }
 
+    public boolean isServerSigningEnabled() {
+        return (serverSecurityMode & 0x01) > 0;
+    }
+
     public NegotiatedProtocol getNegotiatedProtocol() {
         return negotiatedProtocol;
     }


### PR DESCRIPTION
Extracting and exposing metadata as a part of connection setup that is available even if the connection setup fails.