### PR TITLE
Adding windows version info to ConnectionInfo

### DIFF
--- a/src/main/java/com/hierynomus/ntlm/messages/NtlmChallenge.java
+++ b/src/main/java/com/hierynomus/ntlm/messages/NtlmChallenge.java
@@ -37,7 +37,7 @@ public class NtlmChallenge extends NtlmPacket {
     private int targetNameBufferOffset;
     private EnumSet<NtlmNegotiateFlag> negotiateFlags;
     private byte[] serverChallenge;
-    private WindowsVersion version;
+    public WindowsVersion version;
     private int targetInfoLen;
     private int targetInfoBufferOffset;
     private String targetName;

--- a/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
+++ b/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
@@ -22,31 +22,26 @@ public class AuthenticateResponse
    private byte[] negToken;
    private WindowsVersion winVer;
 
-   public AuthenticateResponse(){
-
+   public AuthenticateResponse() {
    }
 
-   public AuthenticateResponse(byte [] negToken){
+   public AuthenticateResponse(byte [] negToken) {
       this.negToken = negToken;
    }
 
-   public WindowsVersion getWinVer()
-   {
+   public WindowsVersion getWinVer() {
       return winVer;
    }
 
-   public void setWinVer(WindowsVersion winVer)
-   {
+   public void setWinVer(WindowsVersion winVer) {
       this.winVer = winVer;
    }
 
-   public byte[] getNegToken()
-   {
+   public byte[] getNegToken() {
       return negToken;
    }
 
-   public void setNegToken(byte[] negToken)
-   {
+   public void setNegToken(byte[] negToken) {
       this.negToken = negToken;
    }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
+++ b/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
@@ -15,17 +15,38 @@
  */
 package com.hierynomus.smbj.auth;
 
-import com.hierynomus.security.SecurityProvider;
-import com.hierynomus.smbj.session.Session;
+import com.hierynomus.ntlm.messages.WindowsVersion;
 
-import java.io.IOException;
-import java.util.Random;
+public class AuthenticateResponse
+{
+   private byte[] negToken;
+   private WindowsVersion winVer;
 
-public interface Authenticator {
+   public AuthenticateResponse(){
 
-    void init(SecurityProvider securityProvider, Random random);
+   }
 
-    boolean supports(AuthenticationContext context);
+   public AuthenticateResponse(byte [] negToken){
+      this.negToken = negToken;
+   }
 
-    AuthenticateResponse authenticate(AuthenticationContext context, byte[] gssToken, Session session) throws IOException;
+   public WindowsVersion getWinVer()
+   {
+      return winVer;
+   }
+
+   public void setWinVer(WindowsVersion winVer)
+   {
+      this.winVer = winVer;
+   }
+
+   public byte[] getNegToken()
+   {
+      return negToken;
+   }
+
+   public void setNegToken(byte[] negToken)
+   {
+      this.negToken = negToken;
+   }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
@@ -64,15 +64,17 @@ public class NtlmAuthenticator implements Authenticator {
     private boolean completed = false;
 
     @Override
-    public byte[] authenticate(final AuthenticationContext context, final byte[] gssToken, Session session) throws IOException {
+    public AuthenticateResponse authenticate(final AuthenticationContext context, final byte[] gssToken, Session session) throws IOException {
         try {
+            AuthenticateResponse response = new AuthenticateResponse();
             if (completed) {
                 return null;
             } else if (!initialized) {
                 logger.debug("Initialized Authentication of {} using NTLM", context.getUsername());
                 NtlmNegotiate ntlmNegotiate = new NtlmNegotiate();
                 initialized = true;
-                return negTokenInit(ntlmNegotiate);
+                response.setNegToken(negTokenInit(ntlmNegotiate));
+                return response;
             } else {
                 logger.debug("Received token: {}", ByteArrayUtils.printHex(gssToken));
                 NtlmFunctions ntlmFunctions = new NtlmFunctions(random, securityProvider);
@@ -86,6 +88,7 @@ public class NtlmAuthenticator implements Authenticator {
                 }
                 logger.debug("Received NTLM challenge from: {}", challenge.getTargetName());
 
+                response.setWinVer(challenge.version);
                 byte[] serverChallenge = challenge.getServerChallenge();
                 byte[] responseKeyNT = ntlmFunctions.NTOWFv2(String.valueOf(context.getPassword()), context.getUsername(), context.getDomain());
                 byte[] ntlmv2ClientChallenge = ntlmFunctions.getNTLMv2ClientChallenge(challenge.getTargetInfo());
@@ -130,13 +133,15 @@ public class NtlmAuthenticator implements Authenticator {
 
                     byte[] mic = ntlmFunctions.hmac_md5(userSessionKey, concatenatedBuffer.getCompactData());
                     resp.setMic(mic);
-                    return negTokenTarg(resp, negTokenTarg.getResponseToken());
+                    response.setNegToken(negTokenTarg(resp, negTokenTarg.getResponseToken()));
+                    return response;
                 } else {
                     NtlmAuthenticate resp = new NtlmAuthenticate(new byte[0], ntlmv2Response,
                         context.getUsername(), context.getDomain(), null, sessionkey, EnumWithValue.EnumUtils.toLong(negotiateFlags),
                         false
                     );
-                    return negTokenTarg(resp, negTokenTarg.getResponseToken());
+                    response.setNegToken(negTokenTarg(resp, negTokenTarg.getResponseToken()));
+                    return response;
                 }
             }
         } catch (SpnegoException spne) {

--- a/src/main/java/com/hierynomus/smbj/auth/SpnegoAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/SpnegoAuthenticator.java
@@ -55,11 +55,11 @@ public class SpnegoAuthenticator implements Authenticator {
     private GSSContext gssContext;
 
     @Override
-    public byte[] authenticate(final AuthenticationContext context, final byte[] gssToken, final Session session) throws IOException {
+    public AuthenticateResponse authenticate(final AuthenticationContext context, final byte[] gssToken, final Session session) throws IOException {
         final GSSAuthenticationContext gssAuthenticationContext = (GSSAuthenticationContext) context;
         try {
-            return Subject.doAs(gssAuthenticationContext.getSubject(), new PrivilegedExceptionAction<byte[]>() {
-                public byte[] run() throws Exception {
+            return Subject.doAs(gssAuthenticationContext.getSubject(), new PrivilegedExceptionAction<AuthenticateResponse>() {
+                public AuthenticateResponse run() throws Exception {
                     return authenticateSession(gssAuthenticationContext, gssToken, session);
                 }
             });
@@ -68,7 +68,7 @@ public class SpnegoAuthenticator implements Authenticator {
         }
     }
 
-    private byte[] authenticateSession(GSSAuthenticationContext context, byte[] gssToken, Session session) throws TransportException {
+    private AuthenticateResponse authenticateSession(GSSAuthenticationContext context, byte[] gssToken, Session session) throws TransportException {
         try {
             logger.debug("Authenticating {} on {} using SPNEGO", context.getUsername(), session.getConnection().getRemoteHostname());
             if (gssContext == null) {
@@ -97,7 +97,8 @@ public class SpnegoAuthenticator implements Authenticator {
                     session.setSigningKey(adjustSessionKeyLength(key.getEncoded()));
                 }
             }
-            return newToken;
+            AuthenticateResponse response = new AuthenticateResponse(newToken);
+            return response;
         } catch (GSSException e) {
             throw new TransportException(e);
         }

--- a/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
+++ b/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
 
-class ConnectionInfo {
+public class ConnectionInfo {
 
     private WindowsVersion winVer;
     // All SMB2 Dialect

--- a/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
+++ b/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
@@ -18,6 +18,7 @@ package com.hierynomus.smbj.connection;
 import com.hierynomus.mssmb2.SMB2GlobalCapability;
 import com.hierynomus.mssmb2.messages.SMB2NegotiateResponse;
 
+import com.hierynomus.ntlm.messages.WindowsVersion;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.UUID;
@@ -26,11 +27,8 @@ import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
 
 class ConnectionInfo {
 
+    private WindowsVersion winVer;
     // All SMB2 Dialect
-    private SessionTable sessionTable = new SessionTable();
-    private SessionTable preauthSessionTable = new SessionTable();
-    private OutstandingRequests outstandingRequests = new OutstandingRequests();
-    private SequenceWindow sequenceWindow;
     private byte[] gssNegotiateToken;
     private UUID serverGuid;
     private String serverName;
@@ -54,7 +52,6 @@ class ConnectionInfo {
         // new SessionTable
         // new OutstandingRequests
         this.clientGuid = clientGuid;
-        this.sequenceWindow = new SequenceWindow();
         this.gssNegotiateToken = new byte[0];
         this.serverName = serverName;
         this.clientCapabilities = EnumSet.of(SMB2GlobalCapability.SMB2_GLOBAL_CAP_DFS);
@@ -68,24 +65,16 @@ class ConnectionInfo {
         serverSecurityMode = response.getSecurityMode();
     }
 
-    SequenceWindow getSequenceWindow() {
-        return sequenceWindow;
-    }
-
-    SessionTable getSessionTable() {
-        return sessionTable;
-    }
-
-    public SessionTable getPreauthSessionTable() {
-        return preauthSessionTable;
-    }
-
     public UUID getClientGuid() {
         return clientGuid;
     }
 
     public boolean isServerRequiresSigning() {
         return (serverSecurityMode & 0x02) > 0;
+    }
+
+    public boolean isServerSigningEnabled() {
+        return (serverSecurityMode & 0x01) > 0;
     }
 
     public NegotiatedProtocol getNegotiatedProtocol() {
@@ -104,16 +93,22 @@ class ConnectionInfo {
         return serverName;
     }
 
-    public OutstandingRequests getOutstandingRequests() {
-        return outstandingRequests;
-    }
-
     public boolean supports(SMB2GlobalCapability capability) {
         return serverCapabilities.contains(capability);
     }
 
     public EnumSet<SMB2GlobalCapability> getClientCapabilities() {
         return clientCapabilities;
+    }
+
+    public WindowsVersion getWinVer()
+    {
+        return winVer;
+    }
+
+    public void setWinVer(WindowsVersion winVer)
+    {
+        this.winVer = winVer;
     }
 
     @Override

--- a/src/test/groovy/com/hierynomus/smbj/connection/StubAuthenticator.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/connection/StubAuthenticator.groovy
@@ -16,6 +16,7 @@
 package com.hierynomus.smbj.connection
 
 import com.hierynomus.security.SecurityProvider
+import com.hierynomus.smbj.auth.AuthenticateResponse
 import com.hierynomus.smbj.auth.AuthenticationContext
 import com.hierynomus.smbj.auth.Authenticator
 import com.hierynomus.smbj.session.Session
@@ -45,7 +46,7 @@ class StubAuthenticator implements Authenticator {
   }
 
   @Override
-  byte[] authenticate(AuthenticationContext context, byte[] gssToken, Session session) throws IOException {
-    return new byte[0]
+  AuthenticateResponse authenticate(AuthenticationContext context, byte[] gssToken, Session session) throws IOException {
+    return new AuthenticateResponse(new byte[0])
   }
 }


### PR DESCRIPTION
As discussed:
1. Moving more `ConnectionInfo` oriented fields out of `Connection` 
2. Adding `WindowsVersion` field to `ConnectionInfo`
3. Returning `WindowsVersion` and the negotiated token as an `AuthenticateResponse` object, instead of `byte[]`

Currently the `AuthenticateResponse` class is bare; may make additions in the future based on useful information extracted from negotiation.