### PR TITLE
Adding windows version info to ConnectionInfo

### DIFF
--- a/src/main/java/com/hierynomus/ntlm/messages/NtlmChallenge.java
+++ b/src/main/java/com/hierynomus/ntlm/messages/NtlmChallenge.java
@@ -152,4 +152,8 @@ public class NtlmChallenge extends NtlmPacket {
     public Object getAvPairObject(AvId key) {
         return this.targetInfo.get(key);
     }
+
+    public WindowsVersion getVersion() {
+        return version;
+    }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
+++ b/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
@@ -26,22 +26,22 @@ public class AuthenticateResponse
     }
 
     public AuthenticateResponse(byte [] negToken) {
-       this.negToken = negToken;
+        this.negToken = negToken;
     }
 
     public WindowsVersion getWinVer() {
-       return winVer;
+        return winVer;
     }
 
     public void setWinVer(WindowsVersion winVer) {
-       this.winVer = winVer;
+        this.winVer = winVer;
     }
 
     public byte[] getNegToken() {
-       return negToken;
+        return negToken;
     }
 
     public void setNegToken(byte[] negToken) {
-       this.negToken = negToken;
+        this.negToken = negToken;
     }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
+++ b/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
@@ -17,10 +17,9 @@ package com.hierynomus.smbj.auth;
 
 import com.hierynomus.ntlm.messages.WindowsVersion;
 
-public class AuthenticateResponse
-{
+public class AuthenticateResponse {
     private byte[] negToken;
-    private WindowsVersion winVer;
+    private WindowsVersion windowsVersion;
 
     public AuthenticateResponse() {
     }
@@ -29,12 +28,12 @@ public class AuthenticateResponse
         this.negToken = negToken;
     }
 
-    public WindowsVersion getWinVer() {
-        return winVer;
+    public WindowsVersion getWindowsVersion() {
+        return windowsVersion;
     }
 
-    public void setWinVer(WindowsVersion winVer) {
-        this.winVer = winVer;
+    public void setWindowsVersion(WindowsVersion windowsVersion) {
+        this.windowsVersion = windowsVersion;
     }
 
     public byte[] getNegToken() {

--- a/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
+++ b/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
@@ -15,17 +15,33 @@
  */
 package com.hierynomus.smbj.auth;
 
-import com.hierynomus.security.SecurityProvider;
-import com.hierynomus.smbj.session.Session;
+import com.hierynomus.ntlm.messages.WindowsVersion;
 
-import java.io.IOException;
-import java.util.Random;
+public class AuthenticateResponse
+{
+   private byte[] negToken;
+   private WindowsVersion winVer;
 
-public interface Authenticator {
+   public AuthenticateResponse() {
+   }
 
-    void init(SecurityProvider securityProvider, Random random);
+   public AuthenticateResponse(byte [] negToken) {
+      this.negToken = negToken;
+   }
 
-    boolean supports(AuthenticationContext context);
+   public WindowsVersion getWinVer() {
+      return winVer;
+   }
 
-    AuthenticateResponse authenticate(AuthenticationContext context, byte[] gssToken, Session session) throws IOException;
+   public void setWinVer(WindowsVersion winVer) {
+      this.winVer = winVer;
+   }
+
+   public byte[] getNegToken() {
+      return negToken;
+   }
+
+   public void setNegToken(byte[] negToken) {
+      this.negToken = negToken;
+   }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
+++ b/src/main/java/com/hierynomus/smbj/auth/AuthenticateResponse.java
@@ -19,29 +19,29 @@ import com.hierynomus.ntlm.messages.WindowsVersion;
 
 public class AuthenticateResponse
 {
-   private byte[] negToken;
-   private WindowsVersion winVer;
+    private byte[] negToken;
+    private WindowsVersion winVer;
 
-   public AuthenticateResponse() {
-   }
+    public AuthenticateResponse() {
+    }
 
-   public AuthenticateResponse(byte [] negToken) {
-      this.negToken = negToken;
-   }
+    public AuthenticateResponse(byte [] negToken) {
+       this.negToken = negToken;
+    }
 
-   public WindowsVersion getWinVer() {
-      return winVer;
-   }
+    public WindowsVersion getWinVer() {
+       return winVer;
+    }
 
-   public void setWinVer(WindowsVersion winVer) {
-      this.winVer = winVer;
-   }
+    public void setWinVer(WindowsVersion winVer) {
+       this.winVer = winVer;
+    }
 
-   public byte[] getNegToken() {
-      return negToken;
-   }
+    public byte[] getNegToken() {
+       return negToken;
+    }
 
-   public void setNegToken(byte[] negToken) {
-      this.negToken = negToken;
-   }
+    public void setNegToken(byte[] negToken) {
+       this.negToken = negToken;
+    }
 }

--- a/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
@@ -88,7 +88,7 @@ public class NtlmAuthenticator implements Authenticator {
                 }
                 logger.debug("Received NTLM challenge from: {}", challenge.getTargetName());
 
-                response.setWinVer(challenge.getVersion());
+                response.setWindowsVersion(challenge.getVersion());
                 byte[] serverChallenge = challenge.getServerChallenge();
                 byte[] responseKeyNT = ntlmFunctions.NTOWFv2(String.valueOf(context.getPassword()), context.getUsername(), context.getDomain());
                 byte[] ntlmv2ClientChallenge = ntlmFunctions.getNTLMv2ClientChallenge(challenge.getTargetInfo());

--- a/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
@@ -64,15 +64,17 @@ public class NtlmAuthenticator implements Authenticator {
     private boolean completed = false;
 
     @Override
-    public byte[] authenticate(final AuthenticationContext context, final byte[] gssToken, Session session) throws IOException {
+    public AuthenticateResponse authenticate(final AuthenticationContext context, final byte[] gssToken, Session session) throws IOException {
         try {
+            AuthenticateResponse response = new AuthenticateResponse();
             if (completed) {
                 return null;
             } else if (!initialized) {
                 logger.debug("Initialized Authentication of {} using NTLM", context.getUsername());
                 NtlmNegotiate ntlmNegotiate = new NtlmNegotiate();
                 initialized = true;
-                return negTokenInit(ntlmNegotiate);
+                response.setNegToken(negTokenInit(ntlmNegotiate));
+                return response;
             } else {
                 logger.debug("Received token: {}", ByteArrayUtils.printHex(gssToken));
                 NtlmFunctions ntlmFunctions = new NtlmFunctions(random, securityProvider);
@@ -86,6 +88,7 @@ public class NtlmAuthenticator implements Authenticator {
                 }
                 logger.debug("Received NTLM challenge from: {}", challenge.getTargetName());
 
+                response.setWinVer(challenge.getVersion());
                 byte[] serverChallenge = challenge.getServerChallenge();
                 byte[] responseKeyNT = ntlmFunctions.NTOWFv2(String.valueOf(context.getPassword()), context.getUsername(), context.getDomain());
                 byte[] ntlmv2ClientChallenge = ntlmFunctions.getNTLMv2ClientChallenge(challenge.getTargetInfo());
@@ -130,13 +133,15 @@ public class NtlmAuthenticator implements Authenticator {
 
                     byte[] mic = ntlmFunctions.hmac_md5(userSessionKey, concatenatedBuffer.getCompactData());
                     resp.setMic(mic);
-                    return negTokenTarg(resp, negTokenTarg.getResponseToken());
+                    response.setNegToken(negTokenTarg(resp, negTokenTarg.getResponseToken()));
+                    return response;
                 } else {
                     NtlmAuthenticate resp = new NtlmAuthenticate(new byte[0], ntlmv2Response,
                         context.getUsername(), context.getDomain(), null, sessionkey, EnumWithValue.EnumUtils.toLong(negotiateFlags),
                         false
                     );
-                    return negTokenTarg(resp, negTokenTarg.getResponseToken());
+                    response.setNegToken(negTokenTarg(resp, negTokenTarg.getResponseToken()));
+                    return response;
                 }
             }
         } catch (SpnegoException spne) {

--- a/src/main/java/com/hierynomus/smbj/auth/SpnegoAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/SpnegoAuthenticator.java
@@ -55,11 +55,11 @@ public class SpnegoAuthenticator implements Authenticator {
     private GSSContext gssContext;
 
     @Override
-    public byte[] authenticate(final AuthenticationContext context, final byte[] gssToken, final Session session) throws IOException {
+    public AuthenticateResponse authenticate(final AuthenticationContext context, final byte[] gssToken, final Session session) throws IOException {
         final GSSAuthenticationContext gssAuthenticationContext = (GSSAuthenticationContext) context;
         try {
-            return Subject.doAs(gssAuthenticationContext.getSubject(), new PrivilegedExceptionAction<byte[]>() {
-                public byte[] run() throws Exception {
+            return Subject.doAs(gssAuthenticationContext.getSubject(), new PrivilegedExceptionAction<AuthenticateResponse>() {
+                public AuthenticateResponse run() throws Exception {
                     return authenticateSession(gssAuthenticationContext, gssToken, session);
                 }
             });
@@ -68,7 +68,7 @@ public class SpnegoAuthenticator implements Authenticator {
         }
     }
 
-    private byte[] authenticateSession(GSSAuthenticationContext context, byte[] gssToken, Session session) throws TransportException {
+    private AuthenticateResponse authenticateSession(GSSAuthenticationContext context, byte[] gssToken, Session session) throws TransportException {
         try {
             logger.debug("Authenticating {} on {} using SPNEGO", context.getUsername(), session.getConnection().getRemoteHostname());
             if (gssContext == null) {
@@ -97,7 +97,8 @@ public class SpnegoAuthenticator implements Authenticator {
                     session.setSigningKey(adjustSessionKeyLength(key.getEncoded()));
                 }
             }
-            return newToken;
+            AuthenticateResponse response = new AuthenticateResponse(newToken);
+            return response;
         } catch (GSSException e) {
             throw new TransportException(e);
         }

--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -195,7 +195,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
 
     private SMB2SessionSetup authenticationRound(Authenticator authenticator, AuthenticationContext authContext, byte[] inputToken, Session session) throws IOException {
         AuthenticateResponse resp = authenticator.authenticate(authContext, inputToken, session);
-        connectionInfo.setWinVer(resp.getWinVer());
+        connectionInfo.setWindowsVersion(resp.getWindowsVersion());
         byte[] securityContext = resp.getNegToken();
 
         SMB2SessionSetup req = new SMB2SessionSetup(connectionInfo.getNegotiatedProtocol().getDialect(), EnumSet.of(SMB2_NEGOTIATE_SIGNING_ENABLED),
@@ -426,8 +426,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
         return transport.isConnected();
     }
 
-    public ConnectionInfo getConnectionInfo()
-    {
+    public ConnectionInfo getConnectionInfo() {
         return connectionInfo;
     }
 

--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -22,6 +22,7 @@ import com.hierynomus.mssmb.SMB1Packet;
 import com.hierynomus.mssmb.messages.SMB1ComNegotiateRequest;
 import com.hierynomus.mssmb2.*;
 import com.hierynomus.mssmb2.messages.*;
+import com.hierynomus.ntlm.messages.WindowsVersion;
 import com.hierynomus.protocol.commons.Factory;
 import com.hierynomus.protocol.commons.buffer.Buffer;
 import com.hierynomus.protocol.commons.concurrent.CancellableFuture;
@@ -30,6 +31,7 @@ import com.hierynomus.protocol.transport.*;
 import com.hierynomus.smb.SMBPacket;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.SmbConfig;
+import com.hierynomus.smbj.auth.AuthenticateResponse;
 import com.hierynomus.smbj.auth.AuthenticationContext;
 import com.hierynomus.smbj.auth.Authenticator;
 import com.hierynomus.smbj.common.SMBRuntimeException;
@@ -66,6 +68,11 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
     private static final DelegatingSMBMessageConverter converter = new DelegatingSMBMessageConverter(new SMB2MessageConverter(), new SMB1MessageConverter());
 
     private ConnectionInfo connectionInfo;
+    private SessionTable sessionTable = new SessionTable();
+    private SessionTable preauthSessionTable = new SessionTable();
+    private OutstandingRequests outstandingRequests = new OutstandingRequests();
+    private SequenceWindow sequenceWindow;
+
     private String remoteName;
 
     private SMBClient client;
@@ -103,6 +110,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
         this.remoteName = hostname;
         this.remotePort = port;
         transport.connect(new InetSocketAddress(hostname, port));
+        this.sequenceWindow = new SequenceWindow();
         this.connectionInfo = new ConnectionInfo(config.getClientGuid(), hostname);
         negotiateDialect();
         logger.info("Successfully connected to: {}", getRemoteHostname());
@@ -123,7 +131,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
     public void close(boolean force) throws Exception {
         try {
             if (!force) {
-                for (Session session : connectionInfo.getSessionTable().activeSessions()) {
+                for (Session session : sessionTable.activeSessions()) {
                     try {
                         session.close();
                     } catch (IOException e) {
@@ -155,7 +163,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
             SMB2SessionSetup receive = authenticationRound(authenticator, authContext, connectionInfo.getGssNegotiateToken(), session);
             long sessionId = receive.getHeader().getSessionId();
             session.setSessionId(sessionId);
-            connectionInfo.getPreauthSessionTable().registerSession(sessionId, session);
+            preauthSessionTable.registerSession(sessionId, session);
             try {
                 while (receive.getHeader().getStatus() == NtStatus.STATUS_MORE_PROCESSING_REQUIRED) {
                     logger.debug("More processing required for authentication of {} using {}", authContext.getUsername(), authenticator);
@@ -172,10 +180,10 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
                 }
                 session.init(receive);
                 logger.info("Successfully authenticated {} on {}, session is {}", authContext.getUsername(), remoteName, session.getSessionId());
-                connectionInfo.getSessionTable().registerSession(session.getSessionId(), session);
+                sessionTable.registerSession(session.getSessionId(), session);
                 return session;
             } finally {
-                connectionInfo.getPreauthSessionTable().sessionClosed(sessionId);
+                preauthSessionTable.sessionClosed(sessionId);
             }
         } catch (SpnegoException | IOException e) {
             throw new SMBRuntimeException(e);
@@ -187,7 +195,9 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
     }
 
     private SMB2SessionSetup authenticationRound(Authenticator authenticator, AuthenticationContext authContext, byte[] inputToken, Session session) throws IOException {
-        byte[] securityContext = authenticator.authenticate(authContext, inputToken, session);
+        AuthenticateResponse resp = authenticator.authenticate(authContext, inputToken, session);
+        connectionInfo.setWinVer(resp.getWinVer());
+        byte[] securityContext = resp.getNegToken();
 
         SMB2SessionSetup req = new SMB2SessionSetup(connectionInfo.getNegotiatedProtocol().getDialect(), EnumSet.of(SMB2_NEGOTIATE_SIGNING_ENABLED),
             connectionInfo.getClientCapabilities());
@@ -226,18 +236,18 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
     public <T extends SMB2Packet> Future<T> send(SMB2Packet packet) throws TransportException {
         lock.lock();
         try {
-            int availableCredits = connectionInfo.getSequenceWindow().available();
+            int availableCredits = sequenceWindow.available();
             int grantCredits = calculateGrantedCredits(packet, availableCredits);
             if (availableCredits == 0) {
                 logger.warn("There are no credits left to send {}, will block until there are more credits available.", packet.getHeader().getMessage());
             }
-            long[] messageIds = connectionInfo.getSequenceWindow().get(grantCredits);
+            long[] messageIds = sequenceWindow.get(grantCredits);
             packet.getHeader().setMessageId(messageIds[0]);
             logger.debug("Granted {} (out of {}) credits to {}", grantCredits, availableCredits, packet);
             packet.getHeader().setCreditRequest(Math.max(SequenceWindow.PREFERRED_MINIMUM_CREDITS - availableCredits - grantCredits, grantCredits));
 
             Request request = new Request(packet.getHeader().getMessageId(), UUID.randomUUID());
-            connectionInfo.getOutstandingRequests().registerOutstanding(request);
+            outstandingRequests.registerOutstanding(request);
             transport.write(packet);
             return request.getFuture(new CancelRequest(request));
         } finally {
@@ -294,12 +304,12 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
 
     private SMB2Packet multiProtocolNegotiate() throws TransportException {
         SMB1Packet negotiatePacket = new SMB1ComNegotiateRequest(config.getSupportedDialects());
-        long l = connectionInfo.getSequenceWindow().get();
+        long l = sequenceWindow.get();
         if (l != 0) {
             throw new IllegalStateException("The SMBv1 SMB_COM_NEGOTIATE packet needs to be the first packet sent.");
         }
         Request request = new Request(l, UUID.randomUUID());
-        connectionInfo.getOutstandingRequests().registerOutstanding(request);
+        outstandingRequests.registerOutstanding(request);
         transport.write(negotiatePacket);
         Future<SMB2Packet> future = request.getFuture(null);
         SMB2Packet packet = Futures.get(future, getConfig().getTransactTimeout(), TimeUnit.MILLISECONDS, TransportException.Wrapper);
@@ -339,15 +349,15 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
         SMB2Packet packet = (SMB2Packet) uncheckedPacket;
         long messageId = packet.getSequenceNumber();
 
-        if (!connectionInfo.getOutstandingRequests().isOutstanding(messageId)) {
+        if (!outstandingRequests.isOutstanding(messageId)) {
             throw new TransportException("Received response with unknown sequence number <<" + messageId + ">>");
         }
 
         // [MS-SMB2].pdf 3.2.5.1.4 Granting Message Credits
-        connectionInfo.getSequenceWindow().creditsGranted(packet.getHeader().getCreditResponse());
-        logger.debug("Server granted us {} credits for {}, now available: {} credits", packet.getHeader().getCreditResponse(), packet, connectionInfo.getSequenceWindow().available());
+        sequenceWindow.creditsGranted(packet.getHeader().getCreditResponse());
+        logger.debug("Server granted us {} credits for {}, now available: {} credits", packet.getHeader().getCreditResponse(), packet, sequenceWindow.available());
 
-        Request request = connectionInfo.getOutstandingRequests().getRequestByMessageId(messageId);
+        Request request = outstandingRequests.getRequestByMessageId(messageId);
         logger.trace("Send/Recv of packet {} took << {} ms >>", packet, System.currentTimeMillis() - request.getTimestamp().getTime());
 
         // [MS-SMB2].pdf 3.2.5.1.5 Handling Asynchronous Responses
@@ -365,10 +375,10 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
         }
 
         if (packet.getHeader().getSessionId() != 0 && (packet.getHeader().getMessage() != SMB2MessageCommandCode.SMB2_SESSION_SETUP)) {
-            Session session = connectionInfo.getSessionTable().find(packet.getHeader().getSessionId());
+            Session session = sessionTable.find(packet.getHeader().getSessionId());
             if (session == null) {
                 // check for a not-yet-authenticated session
-                session = connectionInfo.getPreauthSessionTable().find(packet.getHeader().getSessionId());
+                session = preauthSessionTable.find(packet.getHeader().getSessionId());
                 if (session == null) {
                     logger.warn("Illegal request, no session matching the sessionId: {}", packet.getHeader().getSessionId());
                     //TODO maybe tear down the connection?
@@ -381,7 +391,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
         }
 
         // [MS-SMB2].pdf 3.2.5.1.8 Processing the Response
-        connectionInfo.getOutstandingRequests().receivedResponseFor(messageId).getPromise().deliver(packet);
+        outstandingRequests.receivedResponseFor(messageId).getPromise().deliver(packet);
     }
 
     private void verifyPacketSignature(SMB2Packet packet, Session session) throws TransportException {
@@ -400,7 +410,7 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
 
     @Override
     public void handleError(Throwable t) {
-        connectionInfo.getOutstandingRequests().handleError(t);
+        outstandingRequests.handleError(t);
         try {
             this.close();
         } catch (Exception e) {
@@ -417,10 +427,15 @@ public class Connection implements AutoCloseable, PacketReceiver<SMBPacket<?>> {
         return transport.isConnected();
     }
 
+    public ConnectionInfo getConnectionInfo()
+    {
+        return connectionInfo;
+    }
+
     @Handler
     @SuppressWarnings("unused")
     private void sessionLogoff(SessionLoggedOff loggedOff) {
-        connectionInfo.getSessionTable().sessionClosed(loggedOff.getSessionId());
+        sessionTable.sessionClosed(loggedOff.getSessionId());
         logger.debug("Session << {} >> logged off", loggedOff.getSessionId());
     }
 

--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -22,7 +22,6 @@ import com.hierynomus.mssmb.SMB1Packet;
 import com.hierynomus.mssmb.messages.SMB1ComNegotiateRequest;
 import com.hierynomus.mssmb2.*;
 import com.hierynomus.mssmb2.messages.*;
-import com.hierynomus.ntlm.messages.WindowsVersion;
 import com.hierynomus.protocol.commons.Factory;
 import com.hierynomus.protocol.commons.buffer.Buffer;
 import com.hierynomus.protocol.commons.concurrent.CancellableFuture;

--- a/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
+++ b/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
@@ -27,7 +27,7 @@ import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
 
 public class ConnectionInfo {
 
-    private WindowsVersion winVer;
+    private WindowsVersion windowsVersion;
     // All SMB2 Dialect
     private byte[] gssNegotiateToken;
     private UUID serverGuid;
@@ -101,14 +101,12 @@ public class ConnectionInfo {
         return clientCapabilities;
     }
 
-    public WindowsVersion getWinVer()
-    {
-        return winVer;
+    public WindowsVersion getWindowsVersion() {
+        return windowsVersion;
     }
 
-    public void setWinVer(WindowsVersion winVer)
-    {
-        this.winVer = winVer;
+    public void setWindowsVersion(WindowsVersion windowsVersion) {
+        this.windowsVersion = windowsVersion;
     }
 
     @Override

--- a/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
+++ b/src/main/java/com/hierynomus/smbj/connection/ConnectionInfo.java
@@ -18,19 +18,17 @@ package com.hierynomus.smbj.connection;
 import com.hierynomus.mssmb2.SMB2GlobalCapability;
 import com.hierynomus.mssmb2.messages.SMB2NegotiateResponse;
 
+import com.hierynomus.ntlm.messages.WindowsVersion;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.UUID;
 
 import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
 
-class ConnectionInfo {
+public class ConnectionInfo {
 
+    private WindowsVersion winVer;
     // All SMB2 Dialect
-    private SessionTable sessionTable = new SessionTable();
-    private SessionTable preauthSessionTable = new SessionTable();
-    private OutstandingRequests outstandingRequests = new OutstandingRequests();
-    private SequenceWindow sequenceWindow;
     private byte[] gssNegotiateToken;
     private UUID serverGuid;
     private String serverName;
@@ -54,7 +52,6 @@ class ConnectionInfo {
         // new SessionTable
         // new OutstandingRequests
         this.clientGuid = clientGuid;
-        this.sequenceWindow = new SequenceWindow();
         this.gssNegotiateToken = new byte[0];
         this.serverName = serverName;
         this.clientCapabilities = EnumSet.of(SMB2GlobalCapability.SMB2_GLOBAL_CAP_DFS);
@@ -68,24 +65,16 @@ class ConnectionInfo {
         serverSecurityMode = response.getSecurityMode();
     }
 
-    SequenceWindow getSequenceWindow() {
-        return sequenceWindow;
-    }
-
-    SessionTable getSessionTable() {
-        return sessionTable;
-    }
-
-    public SessionTable getPreauthSessionTable() {
-        return preauthSessionTable;
-    }
-
     public UUID getClientGuid() {
         return clientGuid;
     }
 
     public boolean isServerRequiresSigning() {
         return (serverSecurityMode & 0x02) > 0;
+    }
+
+    public boolean isServerSigningEnabled() {
+        return (serverSecurityMode & 0x01) > 0;
     }
 
     public NegotiatedProtocol getNegotiatedProtocol() {
@@ -104,16 +93,22 @@ class ConnectionInfo {
         return serverName;
     }
 
-    public OutstandingRequests getOutstandingRequests() {
-        return outstandingRequests;
-    }
-
     public boolean supports(SMB2GlobalCapability capability) {
         return serverCapabilities.contains(capability);
     }
 
     public EnumSet<SMB2GlobalCapability> getClientCapabilities() {
         return clientCapabilities;
+    }
+
+    public WindowsVersion getWinVer()
+    {
+        return winVer;
+    }
+
+    public void setWinVer(WindowsVersion winVer)
+    {
+        this.winVer = winVer;
     }
 
     @Override

--- a/src/test/groovy/com/hierynomus/smbj/connection/StubAuthenticator.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/connection/StubAuthenticator.groovy
@@ -16,6 +16,7 @@
 package com.hierynomus.smbj.connection
 
 import com.hierynomus.security.SecurityProvider
+import com.hierynomus.smbj.auth.AuthenticateResponse
 import com.hierynomus.smbj.auth.AuthenticationContext
 import com.hierynomus.smbj.auth.Authenticator
 import com.hierynomus.smbj.session.Session
@@ -45,7 +46,7 @@ class StubAuthenticator implements Authenticator {
   }
 
   @Override
-  byte[] authenticate(AuthenticationContext context, byte[] gssToken, Session session) throws IOException {
-    return new byte[0]
+  AuthenticateResponse authenticate(AuthenticationContext context, byte[] gssToken, Session session) throws IOException {
+    return new AuthenticateResponse(new byte[0])
   }
 }


### PR DESCRIPTION
As discussed:
1. Moving more `ConnectionInfo` oriented fields out of `Connection` 
2. Adding `WindowsVersion` field to `ConnectionInfo`
3. Returning `WindowsVersion` and the negotiated token as an `AuthenticateResponse` object, instead of `byte[]`

Currently the `AuthenticateResponse` class is bare; may make additions in the future based on useful information extracted from negotiation.