### PR TITLE
Fix for issue #198, signature verification fails for CHANGE_NOTIFY response

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
@@ -75,8 +75,6 @@ public class SMB2ChangeNotifyResponse extends SMB2Packet {
             if (nextEntryOffset != 0) {
                 currentPos += nextEntryOffset;
                 buffer.rpos(currentPos);
-            } else {
-                buffer.rpos(currentPos + 12 + (int) fileNameLen);
             }
         } while (nextEntryOffset != 0);
 

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
@@ -72,8 +72,12 @@ public class SMB2ChangeNotifyResponse extends SMB2Packet {
             fileNameLen = buffer.readUInt32();
             fileName = buffer.readString(StandardCharsets.UTF_16LE, (int) fileNameLen / 2);
             notifyInfoList.add(new FileNotifyInfo(action, fileName));
-            currentPos += nextEntryOffset;
-            buffer.rpos(currentPos);
+            if (nextEntryOffset != 0) {
+                currentPos += nextEntryOffset;
+                buffer.rpos(currentPos);
+            } else {
+                buffer.rpos(currentPos + 12 + (int) fileNameLen);
+            }
         } while (nextEntryOffset != 0);
 
         return notifyInfoList;


### PR DESCRIPTION
When there are 2 or more actions returned the buffer read position is calculated incorrectly.