### PR TITLE
Avoid returning a closed connection by the SMBClient class

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
@@ -75,8 +75,6 @@ public class SMB2ChangeNotifyResponse extends SMB2Packet {
             if (nextEntryOffset != 0) {
                 currentPos += nextEntryOffset;
                 buffer.rpos(currentPos);
-            } else {
-                buffer.rpos(currentPos + 12 + (int) fileNameLen);
             }
         } while (nextEntryOffset != 0);
 

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2ChangeNotifyResponse.java
@@ -72,8 +72,12 @@ public class SMB2ChangeNotifyResponse extends SMB2Packet {
             fileNameLen = buffer.readUInt32();
             fileName = buffer.readString(StandardCharsets.UTF_16LE, (int) fileNameLen / 2);
             notifyInfoList.add(new FileNotifyInfo(action, fileName));
-            currentPos += nextEntryOffset;
-            buffer.rpos(currentPos);
+            if (nextEntryOffset != 0) {
+                currentPos += nextEntryOffset;
+                buffer.rpos(currentPos);
+            } else {
+                buffer.rpos(currentPos + 12 + (int) fileNameLen);
+            }
         } while (nextEntryOffset != 0);
 
         return notifyInfoList;

--- a/src/main/java/com/hierynomus/smbj/SMBClient.java
+++ b/src/main/java/com/hierynomus/smbj/SMBClient.java
@@ -83,7 +83,8 @@ public class SMBClient {
     private Connection getEstablishedOrConnect(String hostname, int port) throws IOException {
         synchronized (this) {
             String hostPort = hostname + ":" + port;
-            if (!connectionTable.containsKey(hostPort)) {
+            Connection cachedConnection = connectionTable.get(hostPort);
+            if (cachedConnection == null || !cachedConnection.isConnected()) {
                 Connection connection = new Connection(config, this, bus);
                 try {
                     connection.connect(hostname, port);


### PR DESCRIPTION
Currently SMBClient#connect can return a broken Connection.

```
    private Connection getEstablishedOrConnect(String hostname, int port) throws IOException {
        synchronized (this) {
            String hostPort = hostname + ":" + port;
            if (!connectionTable.containsKey(hostPort)) {
                // create a connection, put it to the connectionTable and return it
            }
            // if a connection is broken/closed we still returning it
            return connectionTable.get(hostPort);
        }
    }
```