### PR TITLE
#226 Adds workaround for W10 1709 when missing ErrorData reserved byte

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/SMB2Error.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Error.java
@@ -44,7 +44,10 @@ public class SMB2Error {
         } else if (byteCount > 0) {
             readErrorData(header, buffer);
         } else if (byteCount == 0) {
-            buffer.skip(1); // ErrorData (1 byte)
+            // Win10 1709 does not provide ErrorData
+            if (buffer.available() > 0) {
+                buffer.skip(1); // ErrorData (1 byte)
+            }
         }
 
         return this;

--- a/src/test/groovy/com/hierynomus/mssmb2/SMB2ErrorSpec.groovy
+++ b/src/test/groovy/com/hierynomus/mssmb2/SMB2ErrorSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2
+
+import com.hierynomus.smb.SMBBuffer
+import spock.lang.Specification
+
+class SMB2ErrorSpec extends Specification {
+
+  def "ErrorData - Empty"() {
+    given:
+    def header = new SMB2Header()
+    def buffer = new SMBBuffer()
+    buffer.putReserved(2)
+    buffer.putReserved(1)
+    buffer.putReserved(1)
+    buffer.putUInt32(0L)
+    buffer.putReserved(1)
+
+    when:
+    def error = new SMB2Error()
+    error.read(header, buffer)
+
+    then:
+    error.getErrorData().size() == 0
+  }
+
+  def "ErrorData - Empty - W10 1709"() {
+    given:
+    def header = new SMB2Header()
+    def buffer = new SMBBuffer()
+    buffer.putReserved(2)
+    buffer.putReserved(1)
+    buffer.putReserved(1)
+    buffer.putUInt32(0L)
+    // No ErrorData reserved byte provided
+
+    when:
+    def error = new SMB2Error()
+    error.read(header, buffer)
+
+    then:
+    error.getErrorData().size() == 0
+  }
+}


### PR DESCRIPTION
#226: Credit to @tliebeck for the suggested workaround.

W10 1709 has a defect which does not provide the expected reserved ErrorData byte when the ByteCount is 0.
This commit works around this issue by making that byte optional.