### PR TITLE
prevent NPE when use close() twice or more

### DIFF
--- a/src/main/java/com/hierynomus/smbj/share/FileOutputStream.java
+++ b/src/main/java/com/hierynomus/smbj/share/FileOutputStream.java
@@ -119,7 +119,7 @@ class FileOutputStream extends OutputStream {
 
         @Override
         public boolean isAvailable() {
-            return !buf.isEmpty();
+            return buf != null && !buf.isEmpty();
         }
 
         @Override

--- a/src/test/groovy/com/hierynomus/smbj/share/FileOutputStreamSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/share/FileOutputStreamSpec.groovy
@@ -1,0 +1,108 @@
+package com.hierynomus.smbj.share
+
+import com.hierynomus.msdtyp.AccessMask
+import com.hierynomus.mserref.NtStatus
+import com.hierynomus.msfscc.FileAttributes
+import com.hierynomus.mssmb2.*
+import com.hierynomus.mssmb2.messages.SMB2CreateRequest
+import com.hierynomus.mssmb2.messages.SMB2CreateResponse
+import com.hierynomus.mssmb2.messages.SMB2WriteRequest
+import com.hierynomus.mssmb2.messages.SMB2WriteResponse
+import com.hierynomus.smbj.SMBClient
+import com.hierynomus.smbj.SmbConfig
+import com.hierynomus.smbj.auth.AuthenticationContext
+import com.hierynomus.smbj.connection.BasicPacketProcessor
+import com.hierynomus.smbj.connection.Connection
+import com.hierynomus.smbj.connection.StubAuthenticator
+import com.hierynomus.smbj.connection.StubTransportLayerFactory
+import spock.lang.Specification
+
+/**
+ * Created by xuthus on 01.11.2017.
+ */
+class FileOutputStreamSpec extends Specification {
+  private File file
+  private Connection connection
+  private ByteArrayOutputStream devNull
+
+  def setup() {
+    devNull = new ByteArrayOutputStream()
+    def responder = new BasicPacketProcessor({ req ->
+      if (req instanceof SMB2CreateRequest)
+        return createResponse()
+      if (req instanceof SMB2WriteRequest)
+        return write(req)
+
+      null
+    })
+
+    def config = SmbConfig.builder()
+      .withReadBufferSize(1024)
+      .withDfsEnabled(false)
+      .withTransportLayerFactory(new StubTransportLayerFactory(responder.&processPacket))
+      .withAuthenticators(new StubAuthenticator.Factory())
+      .build()
+    def client = new SMBClient(config)
+
+    connection = client.connect("127.0.0.1")
+    def session = connection.authenticate(new AuthenticationContext("username", "password".toCharArray(), "domain.com"))
+    def share = session.connectShare("share") as DiskShare
+    file = share.openFile(
+      "file",
+      EnumSet.of(AccessMask.GENERIC_WRITE),
+      EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
+      SMB2ShareAccess.ALL,
+      SMB2CreateDisposition.FILE_OPEN_IF,
+      EnumSet.noneOf(SMB2CreateOptions.class)
+    )
+  }
+
+  def cleanup() {
+    connection.close()
+  }
+
+  def "should allow to close FileOutputStream after closing PrintWriter using it"() {
+    given:
+        FileOutputStream stream = file.outputStream
+    when:
+        stream.withCloseable { out ->
+          out.withPrintWriter { writer ->
+            writer.println "abcdef"
+          }
+        }
+    then:
+        notThrown(NullPointerException)
+    then:
+        stream.isClosed
+  }
+
+  def "should close FileOutputStream after withWriter"() {
+    given:
+        FileOutputStream stream = file.outputStream
+    when:
+        stream.withWriter { writer ->
+          writer.println "abcdef"
+        }
+    then:
+        notThrown(NullPointerException)
+    then:
+        stream.isClosed
+  }
+
+  SMB2Packet createResponse() {
+    def response = new SMB2CreateResponse()
+    response.header.status = NtStatus.STATUS_SUCCESS
+    response.fileAttributes = EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL)
+    response.fileId = new SMB2FileId(new byte[0], new byte[0])
+    response
+  }
+
+  SMB2WriteResponse write(SMB2WriteRequest req) {
+    def response = new SMB2WriteResponse()
+    response.header.status = NtStatus.STATUS_SUCCESS
+    response.bytesWritten = req.maxPayloadSize
+    req.byteProvider.writeChunk(devNull)
+    response
+  }
+
+}

--- a/src/test/groovy/com/hierynomus/smbj/share/FileReadSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/share/FileReadSpec.groovy
@@ -27,7 +27,6 @@ import com.hierynomus.protocol.commons.ByteArrayUtils
 import com.hierynomus.smbj.SMBClient
 import com.hierynomus.smbj.SmbConfig
 import com.hierynomus.smbj.auth.AuthenticationContext
-import com.hierynomus.smbj.common.Check
 import com.hierynomus.smbj.connection.BasicPacketProcessor
 import com.hierynomus.smbj.connection.Connection
 import com.hierynomus.smbj.connection.StubAuthenticator


### PR DESCRIPTION
The behavior of class com.hierynomus.smbj.share.FileOutputStream differs from the behavior of java.io.FileOutputStream when I call close() method twice.

java.io implementation allows to close() already closed object, smbj implementation, I think, allows by design, but prevents by bug.

Of course, it is not good practice to close stream twise, but when we use withCloseable() and closure closes PrintWriter using the stream, its close() called twice.

Correct me, please, if I'm wrong.