### PR TITLE
Fix always got STATUS_USER_SESSION_DELETED when call SMB2Flush

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2Flush.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2Flush.java
@@ -32,8 +32,8 @@ public class SMB2Flush extends SMB2Packet {
         super();
     }
 
-    public SMB2Flush(SMB2Dialect smbDialect, SMB2FileId fileId) {
-        super(24, smbDialect, SMB2MessageCommandCode.SMB2_FLUSH);
+    public SMB2Flush(SMB2Dialect smbDialect, SMB2FileId fileId, long sessionId, long treeId) {
+        super(24, smbDialect, SMB2MessageCommandCode.SMB2_FLUSH, sessionId, treeId);
         this.fileId = fileId;
     }
 

--- a/src/main/java/com/hierynomus/smbj/share/Share.java
+++ b/src/main/java/com/hierynomus/smbj/share/Share.java
@@ -143,7 +143,8 @@ public class Share implements AutoCloseable {
     void flush(SMB2FileId fileId) throws SMBApiException {
         SMB2Flush flushReq = new SMB2Flush(
             dialect,
-            fileId
+            fileId,
+            sessionId, treeId
         );
         sendReceive(flushReq, "Flush", fileId, SUCCESS, writeTimeout);
     }


### PR DESCRIPTION
Previously, we always using zero for sessionId and treeId for SMB2Flush message. This will cause always return STATUS_USER_SESSION_DELETED when calling DiskEntry.flush(). This commit is fixing this issue by passing the correct sessionId and treeId.