### PR TITLE
Avoid excessive privilege on set/query file info/security info

### DIFF
--- a/src/main/java/com/hierynomus/smbj/share/DiskShare.java
+++ b/src/main/java/com/hierynomus/smbj/share/DiskShare.java
@@ -209,7 +209,7 @@ public class DiskShare extends Share {
      * @see Directory#iterator(Class, String)
      */
     public <I extends FileDirectoryQueryableInformation> List<I> list(String path, Class<I> informationClass, String searchPattern) {
-        try (Directory d = openDirectory(path, of(GENERIC_READ), null, ALL, FILE_OPEN, null)) {
+        try (Directory d = openDirectory(path, of(FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, FILE_READ_EA), null, ALL, FILE_OPEN, null)) {
             return d.list(informationClass, searchPattern);
         }
     }
@@ -239,7 +239,7 @@ public class DiskShare extends Share {
      * Get information about the given path.
      **/
     public <F extends FileQueryableInformation> F getFileInformation(String path, Class<F> informationClass) throws SMBApiException {
-        try (DiskEntry e = open(path, of(GENERIC_READ), null, ALL, FILE_OPEN, null)) {
+        try (DiskEntry e = open(path, of(FILE_READ_ATTRIBUTES, FILE_READ_EA), null, ALL, FILE_OPEN, null)) {
             return e.getFileInformation(informationClass);
         }
     }
@@ -287,7 +287,7 @@ public class DiskShare extends Share {
      * Get information for a given path
      **/
     public <F extends FileSettableInformation> void setFileInformation(String path, F information) throws SMBApiException {
-        try (DiskEntry e = open(path, of(GENERIC_WRITE), null, ALL, FILE_OPEN, null)) {
+        try (DiskEntry e = open(path, of(FILE_WRITE_ATTRIBUTES, FILE_WRITE_EA), null, ALL, FILE_OPEN, null)) {
             e.setFileInformation(information);
         }
     }
@@ -371,7 +371,7 @@ public class DiskShare extends Share {
      * The SecurityDescriptor(MS-DTYP 2.4.6 SECURITY_DESCRIPTOR) for the Given Path
      */
     public SecurityDescriptor getSecurityInfo(String path, Set<SecurityInformation> securityInfo) throws SMBApiException {
-        EnumSet<AccessMask> accessMask = of(GENERIC_READ);
+        EnumSet<AccessMask> accessMask = of(READ_CONTROL);
         if (securityInfo.contains(SecurityInformation.SACL_SECURITY_INFORMATION)) {
             accessMask.add(ACCESS_SYSTEM_SECURITY);
         }
@@ -398,7 +398,7 @@ public class DiskShare extends Share {
      * The SecurityDescriptor(MS-DTYP 2.4.6 SECURITY_DESCRIPTOR) for the Given FileId
      */
     public void setSecurityInfo(String path, Set<SecurityInformation> securityInfo, SecurityDescriptor securityDescriptor) throws SMBApiException {
-        Set<AccessMask> accessMask = of(GENERIC_WRITE);
+        Set<AccessMask> accessMask = of(READ_CONTROL);
         if (securityInfo.contains(SecurityInformation.SACL_SECURITY_INFORMATION)) {
             accessMask.add(ACCESS_SYSTEM_SECURITY);
         }


### PR DESCRIPTION
Originally, we are directly using GENERIC_READ/GENERIC_WRITE and this would cause excessive privilege. This commit is avoiding the excessive privilege issue on set or query for both file information class and the security information class.

This is related with #276 .