### PR TITLE
Extra DFS resolver concurrent usage safety 

### DIFF
--- a/src/main/java/com/hierynomus/msdfsc/ReferralCache.java
+++ b/src/main/java/com/hierynomus/msdfsc/ReferralCache.java
@@ -184,7 +184,7 @@ public class ReferralCache {
 
         private final String pathComponent;
         private final Map<String, ReferralCacheNode> childNodes = new ConcurrentHashMap<>();
-        private ReferralCacheEntry entry;
+        private volatile ReferralCacheEntry entry;
 
         ReferralCacheNode(String pathComponent) {
             this.pathComponent = pathComponent;


### PR DESCRIPTION
Make everything that's immutable final
Use atomic get/set for mutable fields