### PR TITLE
Add maximalAccess to TreeConnect and change in treeConnectResponse

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2TreeConnectResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2TreeConnectResponse.java
@@ -15,6 +15,7 @@
  */
 package com.hierynomus.mssmb2.messages;
 
+import com.hierynomus.msdtyp.AccessMask;
 import com.hierynomus.mssmb2.SMB2Packet;
 import com.hierynomus.mssmb2.SMB2ShareCapabilities;
 import com.hierynomus.protocol.commons.buffer.Buffer;
@@ -34,7 +35,7 @@ public class SMB2TreeConnectResponse extends SMB2Packet {
     private byte shareType;
     private long shareFlags;
     private Set<SMB2ShareCapabilities> capabilities;
-    private long maximalAccess;
+    private Set<AccessMask> maximalAccess;
 
     @Override
     protected void readMessage(SMBBuffer buffer) throws Buffer.BufferException {
@@ -43,7 +44,7 @@ public class SMB2TreeConnectResponse extends SMB2Packet {
         buffer.readByte(); // Reserved (1 byte)
         shareFlags = buffer.readUInt32(); // ShareFlags (4 bytes)
         capabilities = toEnumSet(buffer.readUInt32(), SMB2ShareCapabilities.class); // Capabilities (4 bytes)
-        maximalAccess = buffer.readUInt32(); // MaximalAccess (4 bytes)
+        maximalAccess = toEnumSet(buffer.readUInt32(), AccessMask.class); // MaximalAccess (4 bytes)
     }
 
     /**
@@ -81,7 +82,7 @@ public class SMB2TreeConnectResponse extends SMB2Packet {
         return capabilities;
     }
 
-    public long getMaximalAccess() {
+    public Set<AccessMask> getMaximalAccess() {
         return maximalAccess;
     }
 }

--- a/src/main/java/com/hierynomus/smbj/session/Session.java
+++ b/src/main/java/com/hierynomus/smbj/session/Session.java
@@ -174,7 +174,7 @@ public class Session implements AutoCloseable {
             }
 
             long treeId = response.getHeader().getTreeId();
-            TreeConnect treeConnect = new TreeConnect(treeId, smbPath, this, response.getCapabilities(), connection, bus);
+            TreeConnect treeConnect = new TreeConnect(treeId, smbPath, this, response.getCapabilities(), connection, bus, response.getMaximalAccess());
 
             Share share;
             if (response.isDiskShare()) {

--- a/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
+++ b/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
@@ -15,6 +15,7 @@
  */
 package com.hierynomus.smbj.share;
 
+import com.hierynomus.msdtyp.AccessMask;
 import com.hierynomus.mssmb2.SMB2Packet;
 import com.hierynomus.mssmb2.SMB2ShareCapabilities;
 import com.hierynomus.mssmb2.messages.SMB2TreeDisconnect;
@@ -42,14 +43,16 @@ public class TreeConnect {
     private final Set<SMB2ShareCapabilities> capabilities;
     private Connection connection;
     private final SMBEventBus bus;
+    private final Set<AccessMask> maximalAccess;
 
-    public TreeConnect(long treeId, SmbPath smbPath, Session session, Set<SMB2ShareCapabilities> capabilities, Connection connection, SMBEventBus bus) {
+    public TreeConnect(long treeId, SmbPath smbPath, Session session, Set<SMB2ShareCapabilities> capabilities, Connection connection, SMBEventBus bus, Set<AccessMask> maximalAccess) {
         this.treeId = treeId;
         this.smbPath = smbPath;
         this.session = session;
         this.capabilities = capabilities;
         this.connection = connection;
         this.bus = bus;
+        this.maximalAccess = maximalAccess;
     }
 
     Connection getConnection() {
@@ -79,6 +82,10 @@ public class TreeConnect {
 
     public Session getSession() {
         return session;
+    }
+
+    public Set<AccessMask> getMaximalAccess() {
+        return maximalAccess;
     }
 
     public boolean isDfsShare() {

--- a/src/test/groovy/com/hierynomus/mssmb2/messages/SMB2TreeConnectResponseSpec.groovy
+++ b/src/test/groovy/com/hierynomus/mssmb2/messages/SMB2TreeConnectResponseSpec.groovy
@@ -15,8 +15,10 @@
  */
 package com.hierynomus.mssmb2.messages
 
+import com.hierynomus.msdtyp.AccessMask
 import com.hierynomus.mssmb2.SMB2ShareCapabilities
 import com.hierynomus.protocol.commons.ByteArrayUtils
+import com.hierynomus.protocol.commons.EnumWithValue
 import com.hierynomus.smb.SMBBuffer
 import spock.lang.Specification
 
@@ -34,7 +36,7 @@ class SMB2TreeConnectResponseSpec extends Specification {
 
     then:
     tcResponse.getCapabilities() == EnumSet.noneOf(SMB2ShareCapabilities.class)
-    tcResponse.getMaximalAccess() == 0x001f01ffL
+    tcResponse.getMaximalAccess() == EnumWithValue.EnumUtils.toEnumSet(0x001f01ffL, AccessMask.class)
     tcResponse.getShareFlags() == 0x800L
     tcResponse.isDiskShare()
   }


### PR DESCRIPTION
Add maximalAccess to TreeConnect class. Change the getMaximalAccess() in SMB2TreeConnectResponse to Set<AccessMask> instead of long. Change the test case to use Set<AccessMask> to compare instead of using long.

This should allow the client to perform a local checking before actual sending out a request which will get "ACCESS_DENIED" from the server.