### PR TITLE
Bug Fix: Wrong name on creating SpnegoAuthenticator Factory by reflection

### DIFF
--- a/src/main/java/com/hierynomus/smbj/SmbConfig.java
+++ b/src/main/java/com/hierynomus/smbj/SmbConfig.java
@@ -87,7 +87,7 @@ public final class SmbConfig {
         List<Factory.Named<Authenticator>> authenticators = new ArrayList<>();
 
         try {
-            Object spnegoFactory = Class.forName("com.hierynomus.smbj.auth.SpnegoAuthenticator.Factory").newInstance();
+            Object spnegoFactory = Class.forName("com.hierynomus.smbj.auth.SpnegoAuthenticator$Factory").newInstance();
             authenticators.add((Factory.Named<Authenticator>)spnegoFactory);
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | ClassCastException e) {
             // Ignored; probably running on Android


### PR DESCRIPTION
Fix wrong name on creating SpnegoAuthenticator Factory on SmbConfig by reflection. The nested class name should be named as "outerClass$nestedClass" instead of "outerClass.nestedClass".

This code is just add on [here](https://github.com/hierynomus/smbj/commit/975b806164e1e6fbbba3d3e63ed30a036cc52958#diff-7b69131483bcf0d3043d16a5bfbf49b8R90). Without this fix, you will always get "ClassNotFoundException" for the SpnegoAuthenticator Factory.