### PR TITLE
Print status codes as 8 digit hex instead of decimal

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
@@ -226,7 +226,7 @@ public class SMB2Header implements SMBHeader {
             asyncId,
             sessionId,
             treeId,
-            status,
+            statusCode,
             flags,
             nextCommandOffset);
 

--- a/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
@@ -183,6 +183,7 @@ public class SMB2Header implements SMBHeader {
 
     public void setStatus(NtStatus status) {
         this.status = status;
+        this.statusCode = status.getValue();
     }
 
     public NtStatus getStatus() {
@@ -215,7 +216,7 @@ public class SMB2Header implements SMBHeader {
 
     public String toString() {
         return String.format(
-            "dialect=%s, creditCharge=%s, creditRequest=%s, creditResponse=%s, message=%s, messageId=%s, asyncId=%s, sessionId=%s, treeId=%s, status=%s, statusCode=%s, flags=%s, nextCommandOffset=%s",
+            "dialect=%s, creditCharge=%s, creditRequest=%s, creditResponse=%s, message=%s, messageId=%s, asyncId=%s, sessionId=%s, treeId=%s, status=0x%08x, flags=%s, nextCommandOffset=%s",
             dialect,
             creditCharge,
             creditRequest,
@@ -226,7 +227,6 @@ public class SMB2Header implements SMBHeader {
             sessionId,
             treeId,
             status,
-            statusCode,
             flags,
             nextCommandOffset);
 

--- a/src/main/java/com/hierynomus/mssmb2/SMBApiException.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMBApiException.java
@@ -18,6 +18,8 @@ package com.hierynomus.mssmb2;
 import com.hierynomus.mserref.NtStatus;
 import com.hierynomus.smbj.common.SMBRuntimeException;
 
+import java.io.IOException;
+
 public class SMBApiException extends SMBRuntimeException {
     private final NtStatus status;
     private final SMB2MessageCommandCode failedCommand;
@@ -65,6 +67,6 @@ public class SMBApiException extends SMBRuntimeException {
 
     @Override
     public String getMessage() {
-        return status + "(" + status.getValue() + "/" + statusCode + "): " + super.getMessage();
+        return String.format("%s (0x%08x): %s", status.name(), statusCode, super.getMessage());
     }
 }


### PR DESCRIPTION
Hex codes are much more useful when trying to find information about error codes.