### PR TITLE
Fix always fail on query FileBothDirectoryInformation (wrong structure)

### DIFF
--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
@@ -519,7 +519,6 @@ public class FileInformationFactory {
         buffer.readByte(); // Reserved1 (1)
         byte[] shortNameBytes = buffer.readRawBytes(24);// Shortname
         String shortName = new String(shortNameBytes, 0, shortNameLen, Charsets.UTF_16LE);
-        buffer.readUInt16(); // Reserved2
         String fileName = buffer.readString(Charsets.UTF_16LE, (int) fileNameLen / 2);
         FileBothDirectoryInformation fi = new FileBothDirectoryInformation(
             nextOffset, fileIndex, fileName,


### PR DESCRIPTION
Delete the the non-exist Reserved2 in FileBothDirectoryInformation. This should fix query FileBothDirectoryInformation always fail issue.

[MS-FSCC] 2.4.8 FileBothDirectoryInformation Link : https://msdn.microsoft.com/en-us/library/cc232095.aspx