### PR TITLE
Fix not return session expired

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -388,11 +388,11 @@ public class Connection implements Closeable, PacketReceiver<SMBPacket<?>> {
             return;
         }
 
+        // TODO reauthenticate session!
         // [MS-SMB2].pdf 3.2.5.1.6 Handling Session Expiration
-        if (packet.getHeader().getStatus() == NtStatus.STATUS_NETWORK_SESSION_EXPIRED) {
-            // TODO reauthenticate session!
-            return;
-        }
+        // if (packet.getHeader().getStatus() == NtStatus.STATUS_NETWORK_SESSION_EXPIRED) {
+        //     return;
+        // }
 
         if (packet.getHeader().getSessionId() != 0 && (packet.getHeader().getMessage() != SMB2MessageCommandCode.SMB2_SESSION_SETUP)) {
             Session session = sessionTable.find(packet.getHeader().getSessionId());


### PR DESCRIPTION
Fix not return session expired.

Comment the return on Connection receiving STATUS_NETWORK_SESSION_EXPIRED, so that the error status will delivery to responseFuture normally. 

This is trouble for using SPENGO authenticator. The ticket may expired and the client requires to renew his/her ticket from KDC, i.e. Client requires knowledge to perform re-authentication. We should implement the re-authentication separately.