### PR TITLE
Add API for change notify

### DIFF
--- a/src/it/groovy/com/hierynomus/smbj/SMB2DirectoryIntegrationTest.groovy
+++ b/src/it/groovy/com/hierynomus/smbj/SMB2DirectoryIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.smbj
+
+import com.hierynomus.msdtyp.AccessMask
+import com.hierynomus.msfscc.FileAttributes
+import com.hierynomus.msfscc.FileNotifyAction
+import com.hierynomus.mssmb2.SMB2CompletionFilter
+import com.hierynomus.mssmb2.SMB2CreateDisposition
+import com.hierynomus.mssmb2.SMB2ShareAccess
+import com.hierynomus.smbj.auth.AuthenticationContext
+import com.hierynomus.smbj.connection.Connection
+import com.hierynomus.smbj.session.Session
+import com.hierynomus.smbj.share.DiskShare
+import com.hierynomus.smbj.transport.tcp.async.AsyncDirectTcpTransportFactory
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class SMB2DirectoryIntegrationTest extends Specification {
+
+  DiskShare share
+  Session session
+  Connection connection
+  SMBClient client
+
+  def setup() {
+    def config = SmbConfig
+      .builder()
+      .withMultiProtocolNegotiate(true)
+      .withTransportLayerFactory(new AsyncDirectTcpTransportFactory<>())
+      .withSigningRequired(true).build()
+    client = new SMBClient(config)
+    connection = client.connect("127.0.0.1")
+    session = connection.authenticate(new AuthenticationContext("smbj", "smbj".toCharArray(), null))
+    share = session.connectShare("user") as DiskShare
+  }
+
+  def cleanup() {
+    connection.close()
+  }
+
+  def "should notify change"() {
+
+    given:
+    share.mkdir("directory")
+    def directory = share.openDirectory("directory",
+                                   EnumSet.of(AccessMask.GENERIC_READ),
+                                   EnumSet.of(FileAttributes.FILE_ATTRIBUTE_DIRECTORY),
+                                   SMB2ShareAccess.ALL,
+                                   SMB2CreateDisposition.FILE_OPEN,
+                                   null)
+
+    when:
+    def notifyResponseFuture = directory.sendChangeNotifyRequest(EnumSet.of(SMB2CompletionFilter.FILE_NOTIFY_CHANGE_SIZE, SMB2CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME, SMB2CompletionFilter.FILE_NOTIFY_CHANGE_LAST_WRITE),
+                                              65535,
+                                              false)
+    def testNotifyFile001 = share.openFile("TestNotify.txt",
+                                       EnumSet.of(AccessMask.GENERIC_READ, AccessMask.GENERIC_WRITE, AccessMask.DELETE),
+                                       EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
+                                       SMB2ShareAccess.ALL,
+                                       SMB2CreateDisposition.FILE_CREATE,
+                                       null)
+    testNotifyFile001.write("Testing 123 123".getBytes(StandardCharsets.UTF_8), 0)
+
+    then:
+    def notifyResponse = notifyResponseFuture.get()
+    notifyResponse.fileNotifyInfoList != null
+    notifyResponse.fileNotifyInfoList.size() == 1
+    def fileNotifyInfo01 = notifyResponse.fileNotifyInfoList.get(0)
+    fileNotifyInfo01.fileName == "TestNotify.txt"
+    fileNotifyInfo01.action == FileNotifyAction.FILE_ACTION_ADDED
+
+    cleanup:
+    testNotifyFile001.deleteOnClose()
+    testNotifyFile001.close()
+    directory.close()
+    share.rmdir("directory", true)
+  }
+
+}

--- a/src/main/java/com/hierynomus/smbj/share/Directory.java
+++ b/src/main/java/com/hierynomus/smbj/share/Directory.java
@@ -21,12 +21,15 @@ import com.hierynomus.msfscc.fileinformation.FileDirectoryQueryableInformation;
 import com.hierynomus.msfscc.fileinformation.FileIdBothDirectoryInformation;
 import com.hierynomus.msfscc.fileinformation.FileInformation;
 import com.hierynomus.msfscc.fileinformation.FileInformationFactory;
+import com.hierynomus.mssmb2.SMB2CompletionFilter;
 import com.hierynomus.mssmb2.SMB2FileId;
 import com.hierynomus.mssmb2.SMBApiException;
+import com.hierynomus.mssmb2.messages.SMB2ChangeNotifyResponse;
 import com.hierynomus.mssmb2.messages.SMB2QueryDirectoryRequest;
 import com.hierynomus.mssmb2.messages.SMB2QueryDirectoryResponse;
 
 import java.util.*;
+import java.util.concurrent.Future;
 
 public class Directory extends DiskEntry implements Iterable<FileIdBothDirectoryInformation> {
     Directory(SMB2FileId fileId, DiskShare diskShare, String fileName) {
@@ -105,6 +108,18 @@ public class Directory extends DiskEntry implements Iterable<FileIdBothDirectory
      */
     public <F extends FileDirectoryQueryableInformation> Iterator<F> iterator(Class<F> informationClass, String searchPattern) {
         return new DirectoryIterator<>(informationClass, searchPattern);
+    }
+
+    /***
+     * Send a change notify request and and return a Future for change notify response.
+     *
+     * @param completionFilter types of changes to monitor
+     * @param outputBufferLength maximum number of bytes the server is allowed to return
+     * @param recursive monitor changes on any file or directory contained beneath the directory
+     * @return a Future to be used to retrieve the change notify response packet
+     */
+    public Future<SMB2ChangeNotifyResponse> sendChangeNotifyRequest(Set<SMB2CompletionFilter> completionFilter, long outputBufferLength, boolean recursive) {
+        return share.sendChangeNotifyRequest(fileId, completionFilter, outputBufferLength, recursive);
     }
 
     public SMB2FileId getFileId() {

--- a/src/main/java/com/hierynomus/smbj/share/Share.java
+++ b/src/main/java/com/hierynomus/smbj/share/Share.java
@@ -317,6 +317,17 @@ public class Share implements AutoCloseable {
         return send(ioreq);
     }
 
+    Future<SMB2ChangeNotifyResponse> sendChangeNotifyRequest(SMB2FileId fileId, Set<SMB2CompletionFilter> completionFilter, long outputBufferLength, boolean recursive) {
+        SMB2ChangeNotifyRequest qreq = new SMB2ChangeNotifyRequest(
+            dialect,
+            sessionId, treeId,
+            fileId, completionFilter,
+            outputBufferLength, recursive
+        );
+
+        return send(qreq);
+    }
+
     private <T extends SMB2Packet> T sendReceive(SMB2Packet request, String name, Object target, Set<NtStatus> successResponses, long timeout) {
         Future<T> fut = send(request);
         return receive(fut, name, target, successResponses, timeout);


### PR DESCRIPTION
Add API for change notify

The implementation of Smb2 Notify Command already done in Smbj Library previously. This commit is adding an API on the `Directory` class to let the user can simply call the function instead of building the whole request by his/her each time.