### PR TITLE
Add IBM VM alternative

### DIFF
--- a/build-android.gradle
+++ b/build-android.gradle
@@ -55,6 +55,7 @@ android {
     main.java {
       exclude(
         'com/hierynomus/smbj/auth/SpnegoAuthenticator.java',
+        'com/hierynomus/smbj/auth/ExtendedGSSContext.java',
         'com/hierynomus/smbj/auth/GSSAuthenticationContext.java',
         'com/hierynomus/smbj/transport/tcp/async/**/*.java'
       )

--- a/build.gradle
+++ b/build.gradle
@@ -215,10 +215,11 @@ check {
   dependsOn += ['jdependReport']
 }
 
-// KRB5 depends on com.sun.security.jgss classes, but those should normally not be accessed,
+// java.lang.invoke.MethodHandle.invokeExact(Object[]) has a @PolymorphicSignature
+// (see https://github.com/mojohaus/animal-sniffer/issues/18),
 // so we ignore them from the sniffer
 animalsniffer {
-  ignore 'com.sun.security.jgss.*'
+  ignore 'java.lang.invoke.MethodHandle'
 }
 
 jacocoTestReport {

--- a/src/main/java/com/hierynomus/smbj/auth/ExtendedGSSContext.java
+++ b/src/main/java/com/hierynomus/smbj/auth/ExtendedGSSContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.smbj.auth;
+
+import org.ietf.jgss.GSSContext;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.security.Key;
+
+
+import com.hierynomus.protocol.transport.TransportException;
+
+class ExtendedGSSContext {
+    private static final MethodHandle krb5GetSessionKey = getKrb5GetSessionKeyFunction();
+
+    private static MethodHandle getKrb5GetSessionKeyFunction() {
+        Class<?> extendedContextClass;
+        Class<?> inquireTypeClass;
+        try {
+            extendedContextClass = Class.forName("com.sun.security.jgss.ExtendedGSSContext", false, SpnegoAuthenticator.class.getClassLoader());
+            inquireTypeClass = Class.forName("com.sun.security.jgss.InquireType");
+        } catch (ClassNotFoundException e) {
+            try {
+                extendedContextClass = Class.forName("com.ibm.security.jgss.ExtendedGSSContext", false, SpnegoAuthenticator.class.getClassLoader());
+                inquireTypeClass = Class.forName("com.ibm.security.jgss.InquireType");
+            } catch (ClassNotFoundException e1) {
+                IllegalStateException exception = new IllegalStateException("The code is running in an unknown java vm");
+                exception.addSuppressed(e);
+                exception.addSuppressed(e1);
+                throw exception;
+            }
+        }
+        @SuppressWarnings("unchecked")
+        Object getSessionKeyConst = Enum.valueOf(inquireTypeClass.asSubclass(Enum.class), "KRB5_GET_SESSION_KEY");
+        try {
+            MethodHandle handle = MethodHandles.lookup().findVirtual(extendedContextClass, "inquireSecContext", MethodType.methodType(Object.class, inquireTypeClass));
+            return MethodHandles.insertArguments(handle, 0, getSessionKeyConst).asType(MethodType.methodType(Key.class, GSSContext.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static Key krb5GetSessionKey(GSSContext gssContext) throws TransportException {
+        try {
+            return (Key) krb5GetSessionKey.invokeExact(gssContext);
+        } catch (Throwable e) {
+            throw new TransportException(e);
+        }
+    }
+
+    private ExtendedGSSContext() {}
+}

--- a/src/main/java/com/hierynomus/smbj/auth/SpnegoAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/SpnegoAuthenticator.java
@@ -22,8 +22,6 @@ import com.hierynomus.security.SecurityProvider;
 import com.hierynomus.smbj.GSSContextConfig;
 import com.hierynomus.smbj.SmbConfig;
 import com.hierynomus.smbj.session.Session;
-import com.sun.security.jgss.ExtendedGSSContext;
-import com.sun.security.jgss.InquireType;
 import org.ietf.jgss.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,8 +93,7 @@ public class SpnegoAuthenticator implements Authenticator {
 
             AuthenticateResponse response = new AuthenticateResponse(newToken);
             if (gssContext.isEstablished()) {
-                ExtendedGSSContext e = (ExtendedGSSContext) gssContext;
-                Key key = (Key) e.inquireSecContext(InquireType.KRB5_GET_SESSION_KEY);
+                Key key = ExtendedGSSContext.krb5GetSessionKey(gssContext);
                 if (key != null) {
                     // if a session key was negotiated, save it.
                     response.setSigningKey(adjustSessionKeyLength(key.getEncoded()));


### PR DESCRIPTION
If the library is used in a IBM JVM the `com.sun.security.jgss` classes are placed in the `com.ibm.security.jgss` package.
The IBM variant is called via reflection.