### PR TITLE
Implement SMB3 Signing (AesCmac), 3.0.x encryption (AES/CCM) and 3.1.1 encryption (AES/GCM)

### DIFF
--- a/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Header.java
@@ -73,7 +73,6 @@ public class SMB2Header implements SMBHeader {
         if (dialect.isSmb3x()) {
             buffer.putRawBytes(new byte[]{0x0, 0x0}); // ChannelSequence (2 bytes)
             buffer.putReserved(2); // Reserved (2 bytes)
-            throw new UnsupportedOperationException("SMB 3.x not yet implemented");
         } else {
             buffer.putReserved4(); // Status (4 bytes) (reserved on request)
         }

--- a/src/main/java/com/hierynomus/mssmb2/SMB2MessageConverter.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2MessageConverter.java
@@ -21,6 +21,9 @@ import com.hierynomus.protocol.commons.buffer.Buffer;
 import com.hierynomus.smb.SMBPacket;
 import com.hierynomus.smbj.common.SMBRuntimeException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class SMB2MessageConverter {
 
     private static final long FSCTL_PIPE_PEEK = 0x0011400cL;
@@ -28,6 +31,7 @@ public class SMB2MessageConverter {
     private static final long FSCTL_DFS_GET_REFERRALS = 0x00060194L;
     private static final long FSCTL_SRV_COPYCHUNK = 0x001440F2L;
     private static final long FSCTL_SRV_COPYCHUNK_WRITE = 0x001480F2L;
+    private static final Logger logger = LoggerFactory.getLogger(SMB2MessageConverter.class);
 
     private SMB2Packet getPacketInstance(SMB2PacketData packetData) {
         SMB2MessageCommandCode command = packetData.getHeader().getMessage();
@@ -68,6 +72,7 @@ public class SMB2MessageConverter {
             case SMB2_CANCEL:
             case SMB2_OPLOCK_BREAK:
             default:
+                logger.error("Unknown SMB2 Message Command type: " + command);
                 throw new SMBRuntimeException("Unknown SMB2 Message Command type: " + command);
 
         }
@@ -75,6 +80,8 @@ public class SMB2MessageConverter {
 
     public SMB2Packet readPacket(SMBPacket requestPacket, SMB2PacketData packetData) throws Buffer.BufferException {
         SMB2Packet responsePacket = getPacketInstance(packetData);
+        // Pass the from decryption info to the packet
+        responsePacket.setFromDecrypt(packetData.isFromDecrypt());
         if (isSuccess(requestPacket, packetData)) {
             responsePacket.read(packetData);
         } else {

--- a/src/main/java/com/hierynomus/mssmb2/SMB2NegotiateContextType.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2NegotiateContextType.java
@@ -13,14 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hierynomus.security;
+package com.hierynomus.mssmb2;
 
-public interface MessageDigest {
-    void update(byte[] bytes);
+import com.hierynomus.protocol.commons.EnumWithValue;
 
-    byte[] digest();
+public enum SMB2NegotiateContextType implements EnumWithValue<SMB2NegotiateContextType> {
+    SMB2_PREAUTH_INTEGRITY_CAPABILITIES(0x00000001L),
+    SMB2_ENCRYPTION_CAPABILITIES(0x00000002L);
 
-    void reset();
+    private long value;
 
-    int getDigestLength();
+    SMB2NegotiateContextType(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
 }

--- a/src/main/java/com/hierynomus/mssmb2/SMB2Packet.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2Packet.java
@@ -29,6 +29,8 @@ public class SMB2Packet extends SMBPacket<SMB2PacketData, SMB2Header> {
     private SMBBuffer buffer;
     private SMB2Error error;
     private int messageEndPos;
+    private boolean isRequireEncrypt = false;
+    private boolean isFromDecrypt = false;
 
     protected SMB2Packet() {
         super(new SMB2Header());
@@ -170,6 +172,22 @@ public class SMB2Packet extends SMBPacket<SMB2PacketData, SMB2Header> {
      */
     public SMB2Packet getPacket() {
         return this;
+    }
+
+    public boolean isRequireEncrypt() {
+        return isRequireEncrypt;
+    }
+
+    public void setRequireEncrypt(boolean requireEncrypt) {
+        isRequireEncrypt = requireEncrypt;
+    }
+
+    public boolean isFromDecrypt() {
+        return isFromDecrypt;
+    }
+
+    public void setFromDecrypt(boolean fromDecrypt) {
+        isFromDecrypt = fromDecrypt;
     }
 
     @Override

--- a/src/main/java/com/hierynomus/mssmb2/SMB2PacketData.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2PacketData.java
@@ -29,6 +29,8 @@ import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.isSet;
  */
 public class SMB2PacketData extends SMBPacketData<SMB2Header> {
 
+    private boolean isFromDecrypt = false;
+
     public SMB2PacketData(byte[] data) throws Buffer.BufferException {
         super(new SMB2Header(), data);
     }
@@ -51,5 +53,13 @@ public class SMB2PacketData extends SMBPacketData<SMB2Header> {
      */
     public boolean isIntermediateAsyncResponse() {
         return isSet(getHeader().getFlags(), SMB2MessageFlag.SMB2_FLAGS_ASYNC_COMMAND) && getHeader().getStatusCode() == NtStatus.STATUS_PENDING.getValue();
+    }
+
+    public boolean isFromDecrypt() {
+        return isFromDecrypt;
+    }
+
+    public void setFromDecrypt(boolean fromDecrypt) {
+        isFromDecrypt = fromDecrypt;
     }
 }

--- a/src/main/java/com/hierynomus/mssmb2/SMB2SafeIgnorePacketData.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2SafeIgnorePacketData.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2;
+
+import com.hierynomus.protocol.commons.buffer.Buffer;
+import com.hierynomus.smb.SMBBuffer;
+
+public class SMB2SafeIgnorePacketData extends SMB2PacketData {
+
+    public SMB2SafeIgnorePacketData() throws Buffer.BufferException {
+        this(null);
+    }
+
+    private SMB2SafeIgnorePacketData(byte[] data) throws Buffer.BufferException {
+        super(data);
+    }
+
+    public long getSequenceNumber() {
+        return 0L;
+    }
+
+    protected boolean isSuccess() {
+        return false;
+    }
+
+    protected void readHeader() throws Buffer.BufferException {
+        // do nothing
+    }
+
+    @Override
+    public SMB2Header getHeader() {
+        return null;
+    }
+
+    @Override
+    public SMBBuffer getDataBuffer() {
+        return null;
+    }
+}

--- a/src/main/java/com/hierynomus/mssmb2/SMB2ShareFlags.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2ShareFlags.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2;
+
+import com.hierynomus.protocol.commons.EnumWithValue;
+
+/**
+ * [MS-SMB2].pdf 2.2.10 TREE_CONNECT Response ShareFlags
+ */
+public enum SMB2ShareFlags implements EnumWithValue<SMB2ShareFlags> {
+    SMB2_SHAREFLAG_MANUAL_CACHING(0x00000000L),
+    SMB2_SHAREFLAG_AUTO_CACHING(0x00000010L),
+    SMB2_SHAREFLAG_VDO_CACHING(0x00000020L),
+    SMB2_SHAREFLAG_NO_CACHING(0x00000030L),
+    SMB2_SHAREFLAG_DFS(0x00000001L),
+    SMB2_SHAREFLAG_DFS_ROOT(0x00000002L),
+    SMB2_SHAREFLAG_RESTRICT_EXCLUSIVE_OPENS(0x00000100L),
+    SMB2_SHAREFLAG_FORCE_SHARED_DELETE(0x00000200L),
+    SMB2_SHAREFLAG_ALLOW_NAMESPACE_CACHING(0x00000400),
+    SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM(0x00000800),
+    SMB2_SHAREFLAG_FORCE_LEVELII_OPLOCK(0x00001000),
+    SMB2_SHAREFLAG_ENABLE_HASH_V1(0x00002000),
+    SMB2_SHAREFLAG_ENABLE_HASH_V2(0x00004000L),
+    SMB2_SHAREFLAG_ENCRYPT_DATA(0x00008000L),
+    SMB2_SHAREFLAG_IDENTITY_REMOTING(0x00040000L);
+
+    private long value;
+
+    SMB2ShareFlags(long value) {
+        this.value = value;
+    }
+
+    @Override
+    public long getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/hierynomus/mssmb2/SMB2TransformHeaderFunctions.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB2TransformHeaderFunctions.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2;
+
+import com.hierynomus.smb.SMBBuffer;
+
+/***
+ * [MS-SMB2].pdf 2.2.41 SMB2 TRANSFORM_HEADER helper functions
+ */
+public class SMB2TransformHeaderFunctions {
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- ProtocolId (4 bytes)
+    public static final byte[] SMB2_TRANSFORM_HEADER_PROTOCOL_ID = new byte[]{(byte) 0xFD, 'S', 'M', 'B'};
+    // 2.2.41 SMB2 TRANSFORM_HEADER
+    public static final int SMB2_TRANSFORM_HEADER_SIZE = 52;
+    // RFC 5116  section 5.1 and 5.3, https://tools.ietf.org/html/rfc5116#section-5.1
+    public static final int AUTHENTICATION_TAG_LENGTH = 16; // authentication tag with a length of 16 octets (128bits) is used
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- Nonce (16 bytes)
+    public static final int AES128CCM_NONCE_LENGTH = 11;
+    public static final int AES128GCM_NONCE_LENGTH = 12;
+    // 2.2.41 SMB2 TRANSFORM_HEADER - SessionId (8 bytes)
+    public static final int SMB2_TRANSFORM_HEADER_SESSION_ID_OFFSET = 44;
+
+    public static byte[] newAAD(byte[] nonce, int plainTextSize, long sessionId) {
+        SMBBuffer aadTemp = new SMBBuffer();
+
+        aadTemp.putRawBytes(nonce); // Nonce (16 bytes)
+        aadTemp.putUInt32(plainTextSize); // OriginalMessageSize (4 bytes)
+        aadTemp.putReserved2(); // Reserved (2 bytes)
+        aadTemp.putUInt16(1); // Flags/EncryptionAlgorithm (2 bytes)
+        aadTemp.putLong(sessionId); // SessionId (8 bytes)
+
+        return aadTemp.getCompactData();
+    }
+
+    public static byte[] getActualNonce(Smb2EncryptionCipher algorithm, byte[] nonceField) {
+        byte[] nonce;
+        switch (algorithm) {
+            case AES_128_CCM: {
+                nonce = new byte[AES128CCM_NONCE_LENGTH];
+                System.arraycopy(nonceField, 0, nonce, 0, AES128CCM_NONCE_LENGTH);
+                break;
+            }
+            case AES_128_GCM: {
+                nonce = new byte[AES128GCM_NONCE_LENGTH];
+                System.arraycopy(nonceField, 0, nonce, 0, AES128GCM_NONCE_LENGTH);
+                break;
+            }
+            default:
+                throw new IllegalStateException("Unknown encryption algorithm (not supported) when getting nonce.");
+        }
+        return nonce;
+    }
+}

--- a/src/main/java/com/hierynomus/mssmb2/SMB3EncryptedPacketFactory.java
+++ b/src/main/java/com/hierynomus/mssmb2/SMB3EncryptedPacketFactory.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2;
+
+import com.hierynomus.protocol.commons.buffer.Buffer;
+import com.hierynomus.protocol.transport.PacketFactory;
+import com.hierynomus.security.AEADBlockCipher;
+import com.hierynomus.security.Cipher.CryptMode;
+import com.hierynomus.security.DecryptPacketInfo;
+import com.hierynomus.security.SecurityException;
+import com.hierynomus.security.SecurityProvider;
+import com.hierynomus.smb.SMBBuffer;
+import com.hierynomus.smbj.common.Check;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.Key;
+
+import javax.crypto.spec.GCMParameterSpec;
+
+public class SMB3EncryptedPacketFactory implements PacketFactory<SMB2PacketData> {
+    private static final Logger logger = LoggerFactory.getLogger(SMB3EncryptedPacketFactory.class);
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- ProtocolId (4 bytes)
+    private static final byte[] SMB2_TRANSFORM_HEADER_PROTOCOL_ID = SMB2TransformHeaderFunctions.SMB2_TRANSFORM_HEADER_PROTOCOL_ID;
+    // 2.2.41 SMB2 TRANSFORM_HEADER
+    private static final int SMB2_TRANSFORM_HEADER_SIZE = SMB2TransformHeaderFunctions.SMB2_TRANSFORM_HEADER_SIZE;
+    // 2.2.41 SMB2 TRANSFORM_HEADER - SessionId (8 bytes)
+    private static final int SMB2_TRANSFORM_HEADER_SESSION_ID_OFFSET = SMB2TransformHeaderFunctions.SMB2_TRANSFORM_HEADER_SESSION_ID_OFFSET;
+
+    private SMB2PacketFactory smb2PacketFactory;
+    private SecurityProvider securityProvider;
+
+    public SMB3EncryptedPacketFactory(SMB2PacketFactory smb2PacketFactory, SecurityProvider securityProvider) {
+        this.smb2PacketFactory = smb2PacketFactory;
+        this.securityProvider = securityProvider;
+    }
+
+    @Override
+    public SMB2PacketData read(byte[] data) throws Buffer.BufferException {
+        throw new IllegalStateException("Calling to SMB3EncryptedPacketFactory without providing decryptionInfo");
+    }
+
+    public SMB2PacketData read(byte[] data, DecryptPacketInfo decryptPacketInfo) throws Buffer.BufferException {
+        return read(new SMBBuffer(data), decryptPacketInfo);
+    }
+
+    public long readSessionId(byte[] data) throws Buffer.BufferException {
+        SMBBuffer buffer = new SMBBuffer(data);
+        // Check we see a valid header start
+        Check.ensureEquals(buffer.readRawBytes(4), SMB2_TRANSFORM_HEADER_PROTOCOL_ID, "Could not find SMB2_TRANSFORM_HEADER");
+        buffer.skip(SMB2_TRANSFORM_HEADER_SESSION_ID_OFFSET - 4 ); // Skip until sessionId
+        return buffer.readLong(); // SessionId (8 bytes)
+    }
+
+    @Override
+    public boolean canHandle(byte[] data) {
+        return data[0] == (byte) 0xFD && data[1] == 'S' && data[2] == 'M' && data[3] == 'B';
+    }
+
+    private SMB2PacketData read(SMBBuffer buffer, DecryptPacketInfo decryptPacketInfo) throws Buffer.BufferException {
+        if (decryptPacketInfo == null) {
+            logger.error("Unable to decrypt a packet without a decryptionKey");
+            throw new IllegalStateException("Unable to decrypt a packet without a decryptionKey");
+        }
+
+        // 3.2.5.1.1 Decrypting the Message
+        // If the size of the message received from the server is not greater than the size of SMB2
+        // TRANSFORM_HEADER as specified in section 2.2.41, the client MUST discard the message.
+        if (buffer.available() <= SMB2_TRANSFORM_HEADER_SIZE) {
+            return new SMB2SafeIgnorePacketData();
+        }
+
+        // Check we see a valid header start
+        Check.ensureEquals(buffer.readRawBytes(4), SMB2_TRANSFORM_HEADER_PROTOCOL_ID, "Could not find SMB2_TRANSFORM_HEADER");
+        // read the remaining part of the SMB2_TRANSFORM_HEADER
+        byte[] signature = buffer.readRawBytes(16); // Signature (16 bytes)
+        byte[] nonceField = buffer.readRawBytes(16); // Nonce (16 bytes)
+        long originalMessageSize = buffer.readUInt32(); // OriginalMessageSize (4 bytes)
+        buffer.skip(2); // Reserved (2 bytes)
+        int flagsOrEncryptionAlgorithm = buffer.readUInt16(); // Flags/EncryptionAlgorithm (2 bytes)
+        long sessionId = buffer.readLong(); // SessionId (8 bytes)
+        byte[] cipherText = buffer.readRawBytes((int) originalMessageSize); // encrypted packet (variable)
+
+        // 3.2.5.1.1 Decrypting the Message
+        // If the Flags/EncryptionAlgorithm in the SMB2 TRANSFORM_HEADER is not 0x0001,
+        // the client MUST discard the message.
+        if (flagsOrEncryptionAlgorithm != 1) {
+            return new SMB2SafeIgnorePacketData();
+        }
+
+        // decryption part
+        final Key decryptionKey = decryptPacketInfo.getDecryptionKey();
+        final Smb2EncryptionCipher algorithm = decryptPacketInfo.getAlgorithm();
+
+        final byte[] aad = SMB2TransformHeaderFunctions.newAAD(nonceField, (int) originalMessageSize, sessionId);
+        // the nonce actually used in encryption
+        final byte[] nonce = SMB2TransformHeaderFunctions.getActualNonce(algorithm, nonceField);
+        final GCMParameterSpec parameterSpec = new GCMParameterSpec(128, nonce);
+
+        final byte[] plainText;
+        try {
+            plainText = privateDecrypt(cipherText, algorithm, decryptionKey, aad, parameterSpec, signature);
+        } catch (SecurityException e) {
+            // TODO handle the exception properly
+            logger.error("Unable to decrypt a packet on sessionId {}", sessionId);
+            throw new IllegalStateException(e);
+        }
+
+        // decryption is done, parse the SMB2Packet by the Smb2MessageConverter then return it
+        if (smb2PacketFactory.canHandle(plainText)) {
+            SMB2PacketData packetData = smb2PacketFactory.read(plainText);
+            // isFromDecrypt is always true in here as we just finished the decrypt.
+            packetData.setFromDecrypt(true);
+            return packetData;
+        } else {
+            // TODO handle the exception properly
+            logger.error("Unable to get valid Smb2 Packet after decrypt a packet on sessionId {}", sessionId);
+            throw new IllegalStateException("Unable to get valid Smb2 Packet after decrypt a packet on sessionId" + sessionId);
+        }
+    }
+
+    private byte[] privateDecrypt(byte[] cipherText, Smb2EncryptionCipher algorithm, Key decryptionKey, byte[] aad, GCMParameterSpec parameterSpec, byte[] signature) throws SecurityException {
+        byte[] plainText;
+        try {
+            AEADBlockCipher aeadBlockCipher = securityProvider.getAEADBlockCipher(algorithm.getAlgorithmName());
+            aeadBlockCipher.init(CryptMode.DECRYPT, decryptionKey.getEncoded(), parameterSpec);
+            aeadBlockCipher.updateAAD(aad, 0, aad.length);
+            byte[] returnedBytes01 = aeadBlockCipher.update(cipherText, 0, cipherText.length);
+            byte[] returnedBytes02 = aeadBlockCipher.doFinal(signature, 0 , signature.length);
+
+            // Assuming returnedBytes02 will be never null or empty as only CCM and GCM are used.
+            if (returnedBytes01 != null && returnedBytes01.length != 0) {
+                plainText = new byte[returnedBytes01.length + returnedBytes02.length];
+                System.arraycopy(returnedBytes01, 0, plainText, 0, returnedBytes01.length);
+                System.arraycopy(returnedBytes02, 0, plainText, returnedBytes01.length, returnedBytes02.length);
+            } else {
+                plainText = returnedBytes02;
+            }
+        } catch (SecurityException e) {
+            logger.error("Unable to decrypt message, error occur : ", e);
+            throw e;
+        }
+        return plainText;
+    }
+
+}

--- a/src/main/java/com/hierynomus/mssmb2/Smb2EncryptionCipher.java
+++ b/src/main/java/com/hierynomus/mssmb2/Smb2EncryptionCipher.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2;
+
+import com.hierynomus.protocol.commons.EnumWithValue;
+
+/***
+ * [MS-SMB2].pdf 2.2.3.1.2 SMB2_ENCRYPTION_CAPABILITIES -- Cipher
+ */
+public enum Smb2EncryptionCipher implements EnumWithValue<Smb2EncryptionCipher> {
+    AES_128_CCM(0x00000001L),
+    AES_128_GCM(0x00000002L);
+
+    private long value;
+
+    Smb2EncryptionCipher(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public String getAlgorithmName() {
+        switch (this) {
+            case AES_128_CCM:
+                return "AES/CCM/NoPadding";
+            case AES_128_GCM:
+                return "AES/GCM/NoPadding";
+            default:
+                return "";
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/mssmb2/Smb2HashAlgorithm.java
+++ b/src/main/java/com/hierynomus/mssmb2/Smb2HashAlgorithm.java
@@ -13,14 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hierynomus.security;
+package com.hierynomus.mssmb2;
 
-public interface MessageDigest {
-    void update(byte[] bytes);
+import com.hierynomus.protocol.commons.EnumWithValue;
 
-    byte[] digest();
+/***
+ * [MS-SMB2].pdf 2.2.3.1.2 SMB2_ENCRYPTION_CAPABILITIES -- Cipher
+ */
+public enum Smb2HashAlgorithm implements EnumWithValue<Smb2HashAlgorithm> {
+    SHA_512(0x00000001L);
 
-    void reset();
+    private long value;
 
-    int getDigestLength();
+    Smb2HashAlgorithm(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public String getAlgorithmName() {
+        switch (this) {
+            case SHA_512:
+                return "SHA-512";
+            default:
+                return "";
+        }
+    }
+
 }

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2CancelRequest.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2CancelRequest.java
@@ -26,8 +26,20 @@ import com.hierynomus.smb.SMBBuffer;
  */
 public class SMB2CancelRequest extends SMB2Packet {
 
+    /***
+     * Deprecated API for compability. Without sessionId, cancel will always failed/ignored by Server.
+     *
+     * @param dialect Dialect of the SMB2 Protocol
+     * @param messageId the messageId of the operation want to cancel
+     * @param asyncId the asyncId of the operation want to cancel
+     */
+    @Deprecated
     public SMB2CancelRequest(SMB2Dialect dialect, long messageId, long asyncId) {
-        super(4, dialect, SMB2MessageCommandCode.SMB2_CANCEL);
+        this(dialect, messageId, 0L, asyncId);
+    }
+
+    public SMB2CancelRequest(SMB2Dialect dialect, long messageId, long sessionId, long asyncId) {
+        super(4, dialect, SMB2MessageCommandCode.SMB2_CANCEL, sessionId);
         header.setMessageId(messageId);
         if (asyncId != 0) {
             header.setFlag(SMB2MessageFlag.SMB2_FLAGS_ASYNC_COMMAND);

--- a/src/main/java/com/hierynomus/mssmb2/messages/SMB2TreeConnectResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/SMB2TreeConnectResponse.java
@@ -18,12 +18,14 @@ package com.hierynomus.mssmb2.messages;
 import com.hierynomus.msdtyp.AccessMask;
 import com.hierynomus.mssmb2.SMB2Packet;
 import com.hierynomus.mssmb2.SMB2ShareCapabilities;
+import com.hierynomus.mssmb2.SMB2ShareFlags;
 import com.hierynomus.protocol.commons.buffer.Buffer;
 import com.hierynomus.smb.SMBBuffer;
 
 import java.util.Set;
 
 import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
+import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toLong;
 
 /**
  * [MS-SMB2].pdf 2.2.10 SMB2 TREE_CONNECT Response
@@ -33,7 +35,7 @@ import static com.hierynomus.protocol.commons.EnumWithValue.EnumUtils.toEnumSet;
 public class SMB2TreeConnectResponse extends SMB2Packet {
 
     private byte shareType;
-    private long shareFlags;
+    private Set<SMB2ShareFlags> shareFlags;
     private Set<SMB2ShareCapabilities> capabilities;
     private Set<AccessMask> maximalAccess;
 
@@ -42,7 +44,7 @@ public class SMB2TreeConnectResponse extends SMB2Packet {
         buffer.skip(2); // StructureSize (2 bytes)
         shareType = buffer.readByte(); // ShareType (1 byte)
         buffer.readByte(); // Reserved (1 byte)
-        shareFlags = buffer.readUInt32(); // ShareFlags (4 bytes)
+        shareFlags = toEnumSet(buffer.readUInt32(), SMB2ShareFlags.class); // ShareFlags (4 bytes)
         capabilities = toEnumSet(buffer.readUInt32(), SMB2ShareCapabilities.class); // Capabilities (4 bytes)
         maximalAccess = toEnumSet(buffer.readUInt32(), AccessMask.class); // MaximalAccess (4 bytes)
     }
@@ -75,6 +77,10 @@ public class SMB2TreeConnectResponse extends SMB2Packet {
     }
 
     public long getShareFlags() {
+        return toLong(shareFlags);
+    }
+
+    public Set<SMB2ShareFlags> getShareFlagsSet() {
         return shareFlags;
     }
 

--- a/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2EncryptionCapabilitiesRequest.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2EncryptionCapabilitiesRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2.messages.submodule;
+
+import com.hierynomus.mssmb2.SMB2NegotiateContextType;
+import com.hierynomus.mssmb2.Smb2EncryptionCipher;
+import com.hierynomus.smb.SMBBuffer;
+
+import java.util.List;
+
+/***
+ * [MS-SMB2].pdf 2.2.3.1.2 SMB2_ENCRYPTION_CAPABILITIES Request
+ */
+public class SMB2EncryptionCapabilitiesRequest extends SMB2NegotiateContext {
+
+    // CipherCount is always 2 bytes
+    private static final int FIXED_CIPHER_COUNT_SIZE = 2;
+    private List<Smb2EncryptionCipher> cipherList;
+
+    public SMB2EncryptionCapabilitiesRequest(List<Smb2EncryptionCipher> cipherList) {
+        super(SMB2NegotiateContextType.SMB2_ENCRYPTION_CAPABILITIES, FIXED_CIPHER_COUNT_SIZE +  2 * cipherList.size());
+        this.cipherList = cipherList;
+    }
+
+    @Override
+    protected void writeTo(SMBBuffer buffer) {
+        if (cipherList != null) {
+            buffer.putUInt16(cipherList.size()); // CipherCount (2 bytes)
+            // Ciphers (variable)
+            for (Smb2EncryptionCipher encryptionCipher: cipherList) {
+                buffer.putUInt16((int) encryptionCipher.getValue()); // 16-bit integer IDs
+            }
+        } else {
+            // FIXME log the error state
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2EncryptionCapabilitiesResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2EncryptionCapabilitiesResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2.messages.submodule;
+
+import com.hierynomus.mssmb2.Smb2EncryptionCipher;
+import com.hierynomus.protocol.commons.EnumWithValue;
+import com.hierynomus.protocol.commons.buffer.Buffer;
+import com.hierynomus.smb.SMBBuffer;
+
+/***
+ * [MS-SMB2].pdf 2.2.4.1.2 SMB2_ENCRYPTION_CAPABILITIES Response
+ */
+public class SMB2EncryptionCapabilitiesResponse extends SMB2NegotiateContext {
+
+    // the CipherCount is always 1 for response.
+    private Smb2EncryptionCipher cipher;
+
+    @Override
+    protected void readMessage(SMBBuffer buffer) throws Buffer.BufferException {
+        buffer.readUInt16(); // CipherCount (2 bytes), should always is 1.
+        cipher = EnumWithValue.EnumUtils.valueOf(buffer.readUInt16(), Smb2EncryptionCipher.class, null); // Ciphers (2 bytes)
+    }
+
+    public Smb2EncryptionCipher getEncryptionCipher() {
+        return cipher;
+    }
+
+}

--- a/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2NegotiateContext.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2NegotiateContext.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2.messages.submodule;
+
+import com.hierynomus.mssmb2.SMB2NegotiateContextType;
+import com.hierynomus.protocol.commons.EnumWithValue;
+import com.hierynomus.protocol.commons.buffer.Buffer;
+import com.hierynomus.smb.SMBBuffer;
+
+public abstract class SMB2NegotiateContext {
+
+    private SMB2NegotiateContextType negotiateContextType;
+    private int dataLength;
+    private int dataAlignment;
+
+    private SMBBuffer buffer;
+
+    /***
+     * For response to create instance
+     */
+    protected SMB2NegotiateContext() {
+    }
+
+    /***
+     *  For request to create instance
+     *
+     * @param negotiateContextType the type of this negotiateContext
+     * @param dataLength the length of the data (the buffer field) in this negotiateContext
+     */
+    protected SMB2NegotiateContext(final SMB2NegotiateContextType negotiateContextType, final int dataLength) {
+        this.negotiateContextType = negotiateContextType;
+        this.dataLength = dataLength;
+        // make sure after write data is 8 byte alignment. Cast is safe, it will always be 0 ~ 7.
+        this.dataAlignment = (dataLength % 8) == 0 ? 0 : (8 - (dataLength % 8));
+    }
+
+    /***
+     * Method to call for writing the Negotiate Context (one instance) to the buffer
+     *
+     * @param buffer the destination buffer to write to
+     */
+    public void write(SMBBuffer buffer) {
+        privateWriteTo(buffer);
+        writeTo(buffer);
+        if (this.dataAlignment > 0) {
+            // put the alignment bytes
+            buffer.putReserved(this.dataAlignment);
+        }
+    }
+
+    /**
+     * Write the negotiate context fields into the buffer, as specified in the [MS-SMB2].pdf specification.
+     */
+    protected void writeTo(SMBBuffer buffer) {
+        throw new UnsupportedOperationException("Should be implemented by specific message type");
+    }
+
+    private void privateWriteTo(SMBBuffer buffer) {
+        buffer.putUInt16((int) negotiateContextType.getValue()); // ContextType (2 bytes)
+        buffer.putUInt16(dataLength); // DataLength (2 bytes)
+        buffer.putReserved4(); // Reserved (4 bytes)
+    }
+
+    public final void read(SMBBuffer buffer) throws Buffer.BufferException {
+        this.buffer = buffer; // remember the buffer we read it from
+        privateReadFrom(buffer);
+        readMessage(buffer);
+        if (this.dataAlignment > 0 && buffer.available() >= this.dataAlignment) {
+            // skip the alignment bytes, only when the context is not the last element
+            buffer.skip(this.dataAlignment);
+        }
+    }
+
+    /**
+     * Read the negotiate context
+     *
+     * @param buffer the buffer to read context
+     * @throws Buffer.BufferException
+     */
+    protected void readMessage(SMBBuffer buffer) throws Buffer.BufferException {
+        throw new UnsupportedOperationException("Should be implemented by specific message type");
+    }
+
+    private void privateReadFrom(SMBBuffer buffer) throws Buffer.BufferException {
+        this.negotiateContextType = EnumWithValue.EnumUtils.valueOf(buffer.readUInt16(), SMB2NegotiateContextType.class, null); // ContextType (2 bytes)
+        this.dataLength = buffer.readUInt16(); // DataLength (2 bytes)
+        // make sure after write data is 8 byte alignment. Cast is safe, it will always be 0 ~ 7.
+        this.dataAlignment = (dataLength % 8) == 0 ? 0 : (8 - (dataLength % 8));
+        buffer.skip(4); // Reserved (4 bytes)
+    }
+
+    protected int getDataAlignment() {
+        return this.dataAlignment;
+    }
+
+    public SMB2NegotiateContextType getNegotiateContextType() {
+        return negotiateContextType;
+    }
+}

--- a/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2PreauthIntegrityCapabilitiesRequest.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2PreauthIntegrityCapabilitiesRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2.messages.submodule;
+
+import com.hierynomus.mssmb2.SMB2NegotiateContextType;
+import com.hierynomus.mssmb2.Smb2HashAlgorithm;
+import com.hierynomus.smb.SMBBuffer;
+
+import java.util.List;
+
+/***
+ * [MS-SMB2].pdf 2.2.3.1.1 SMB2_PREAUTH_INTEGRITY_CAPABILITIES Request
+ */
+public class SMB2PreauthIntegrityCapabilitiesRequest extends SMB2NegotiateContext {
+
+    // HashAlgorithmCount (2 bytes) + SaltLength (2 bytes) is always 4 bytes
+    private static final int FIXED_PART_SIZE = 4;
+    // [MS-SMB2].pdf <103> Section 3.2.4.2.2.2: Windows 10, Windows Server 2016, and Windows Server operating
+    // system use 32 bytes of Salt.
+    public static final int DEFAULT_SALT_LENGTH = 32;
+    private List<Smb2HashAlgorithm> hashAlgorithmList;
+    private byte[] salt;
+
+    public SMB2PreauthIntegrityCapabilitiesRequest(List<Smb2HashAlgorithm> hashAlgorithmList, byte[] salt) {
+        super(SMB2NegotiateContextType.SMB2_PREAUTH_INTEGRITY_CAPABILITIES, FIXED_PART_SIZE + 2 * hashAlgorithmList.size() + salt.length);
+        this.hashAlgorithmList = hashAlgorithmList;
+        this.salt = salt.clone();
+    }
+
+    @Override
+    protected void writeTo(SMBBuffer buffer) {
+        if (hashAlgorithmList != null && salt != null) {
+            buffer.putUInt16(hashAlgorithmList.size()); // HashAlgorithmCount (2 bytes)
+            buffer.putUInt16(salt.length); // SaltLength (2 bytes)
+            // HashAlgorithms (variable)
+            for (Smb2HashAlgorithm hashAlgorithm: hashAlgorithmList) {
+                buffer.putUInt16((int) hashAlgorithm.getValue()); // 16-bit integer IDs
+            }
+            buffer.putRawBytes(salt); // Salt (variable)
+        } else {
+            // FIXME log the error state
+        }
+    }
+
+}

--- a/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2PreauthIntegrityCapabilitiesResponse.java
+++ b/src/main/java/com/hierynomus/mssmb2/messages/submodule/SMB2PreauthIntegrityCapabilitiesResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2.messages.submodule;
+
+import com.hierynomus.mssmb2.Smb2HashAlgorithm;
+import com.hierynomus.protocol.commons.EnumWithValue;
+import com.hierynomus.protocol.commons.buffer.Buffer;
+import com.hierynomus.smb.SMBBuffer;
+
+/***
+ * [MS-SMB2].pdf 2.2.3.1.1 SMB2_PREAUTH_INTEGRITY_CAPABILITIES Response
+ */
+public class SMB2PreauthIntegrityCapabilitiesResponse extends SMB2NegotiateContext {
+
+    // the HashAlgorithm is always 1 for response.
+    private Smb2HashAlgorithm hashAlgorithm;
+    private byte[] salt;
+
+    @Override
+    protected void readMessage(SMBBuffer buffer) throws Buffer.BufferException {
+        buffer.readUInt16(); // HashAlgorithmCount (2 bytes), should always is 1.
+        int saltLength = buffer.readUInt16(); // SaltLength (2 bytes)
+        hashAlgorithm = EnumWithValue.EnumUtils.valueOf(buffer.readUInt16(), Smb2HashAlgorithm.class, null); // HashAlgorithm (2 bytes)
+        salt = buffer.readRawBytes(saltLength); // Salt (variable)
+    }
+
+    public Smb2HashAlgorithm getHashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    public byte[] getSalt() {
+        return salt;
+    }
+}

--- a/src/main/java/com/hierynomus/security/AEADBlockCipher.java
+++ b/src/main/java/com/hierynomus/security/AEADBlockCipher.java
@@ -15,12 +15,18 @@
  */
 package com.hierynomus.security;
 
-public interface MessageDigest {
-    void update(byte[] bytes);
+import javax.crypto.spec.GCMParameterSpec;
 
-    byte[] digest();
+public interface AEADBlockCipher {
+
+    void init(Cipher.CryptMode cryptMode, byte[] bytes, GCMParameterSpec gcmParameterSpec) throws SecurityException;
+
+    void updateAAD(byte[] aad, int aadOffset, int aadLength) throws SecurityException;
+
+    byte[] update(byte[] in, int inOffset, int inLength) throws SecurityException;
+
+    byte[] doFinal(byte[] in, int inOffset, int inLength) throws SecurityException;
 
     void reset();
 
-    int getDigestLength();
 }

--- a/src/main/java/com/hierynomus/security/CryptographicKeysGenerator.java
+++ b/src/main/java/com/hierynomus/security/CryptographicKeysGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.security;
+
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.KDFCounterBytesGenerator;
+import org.bouncycastle.crypto.macs.HMac;
+import org.bouncycastle.crypto.params.KDFCounterParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.Key;
+
+import javax.crypto.spec.SecretKeySpec;
+
+// [MS-SMB2] 3.1.4.2 Generating Cryptographic Keys
+public class CryptographicKeysGenerator {
+    private static final Logger logger = LoggerFactory.getLogger(CryptographicKeysGenerator.class);
+
+    // [MS-SMB2].pdf 3.3.5.5.3 Handling GSS-API Authentication
+    // NIST Special Publication 800-108, 5.1 KDF in Counter Mode
+    private static final int KDF_R_VALUE = 32;
+    private static final int KDF_L_VALUE = 16; // 16 bytes == 128 bits
+    private static final byte[] KDF_L_VALUE_BYTE_ARRAY = new byte[] {(byte)0x0, (byte)0x0, (byte)0x0, (byte)0x80}; // 128 in 4 bytes, big endian
+    private static final int Smb30xFixedSuffixLength = 25;
+    // SMB2AESCMAC, including the terminating null character
+    public static final byte[] Smb30xSigningLabelByteArray = new byte[]{(byte)'S', (byte)'M', (byte)'B', (byte)'2', (byte)'A', (byte)'E', (byte)'S', (byte)'C', (byte)'M', (byte)'A', (byte)'C', (byte)'\0'};
+    // SmbSign, including the terminating null character
+    public static final byte[] Smb30xSigningContextByteArray = new byte[]{(byte)'S', (byte)'m', (byte)'b', (byte)'S', (byte)'i', (byte)'g', (byte)'n', (byte)'\0'};
+    // SMB2AESCCM, including the terminating null character
+    public static final byte[] Smb30xEncryptLabelByteArray = new byte[]{(byte)'S', (byte)'M', (byte)'B', (byte)'2', (byte)'A', (byte)'E', (byte)'S', (byte)'C', (byte)'C', (byte)'M', (byte)'\0'};
+    // ServerIn , including the suffix space and the terminating null character
+    public static final byte[] Smb30xEncryptContextByteArray = new byte[]{(byte)'S', (byte)'e', (byte)'r', (byte)'v', (byte)'e', (byte)'r', (byte)'I', (byte)'n', (byte)' ', (byte)'\0'};
+    // SMB2AESCCM, including the terminating null character
+    public static final byte[] Smb30xDecryptLabelByteArray = new byte[]{(byte)'S', (byte)'M', (byte)'B', (byte)'2', (byte)'A', (byte)'E', (byte)'S', (byte)'C', (byte)'C', (byte)'M', (byte)'\0'};
+    // ServerOut, including the terminating null character
+    public static final byte[] Smb30xDecryptContextByteArray = new byte[]{(byte)'S', (byte)'e', (byte)'r', (byte)'v', (byte)'e', (byte)'r', (byte)'O', (byte)'u', (byte)'t', (byte)'\0'};
+    // SMBSigningKey, including the terminating null character
+    public static final byte[] Smb311SigningLabelByteArray = new byte[]{(byte)'S', (byte)'M', (byte)'B', (byte)'S', (byte)'i', (byte)'g', (byte)'n', (byte)'i', (byte)'n', (byte)'g', (byte)'K', (byte)'e', (byte)'y', (byte)'\0'};
+    // SMBC2SCipherKey, including the terminating null character
+    public static final byte[] Smb311EncryptLabelByteArray = new byte[]{(byte)'S', (byte)'M', (byte)'B', (byte)'C', (byte)'2', (byte)'S', (byte)'C', (byte)'i', (byte)'p', (byte)'h', (byte)'e', (byte)'r', (byte)'K', (byte)'e', (byte)'y', (byte)'\0'};
+    // SMBS2CCipherKey, including the terminating null character
+    public static final byte[] Smb311DecryptLabelByteArray = new byte[]{(byte)'S', (byte)'M', (byte)'B', (byte)'S', (byte)'2', (byte)'C', (byte)'C', (byte)'i', (byte)'p', (byte)'h', (byte)'e', (byte)'r', (byte)'K', (byte)'e', (byte)'y', (byte)'\0'};
+
+    public static SecretKeySpec generateKey(Key sessionKey, byte[] label, byte[] context, String algorithm) {
+        // TODO add method in security provider instead of always use the BC direct
+
+        // check is the input parameter is valid or not.
+        if (sessionKey == null || sessionKey.getEncoded() == null || label == null || context == null || algorithm == null) {
+            logger.error("Unable to generate key, cause by inputting null as parameter. Return null.");
+            return null;
+        }
+
+        ByteArrayOutputStream fixedSuffixTemp = new ByteArrayOutputStream(Smb30xFixedSuffixLength);
+        try {
+            fixedSuffixTemp.write(label);
+            fixedSuffixTemp.write(0);
+            fixedSuffixTemp.write(context);
+            fixedSuffixTemp.write(KDF_L_VALUE_BYTE_ARRAY);
+        } catch (IOException e) {
+            logger.error("Unable to format suffix, error occur : ", e);
+            return null;
+        }
+
+        byte[] fixedSuffix = fixedSuffixTemp.toByteArray();
+        KDFCounterBytesGenerator
+            kdfGenerator = new KDFCounterBytesGenerator(new HMac(new SHA256Digest()));
+        kdfGenerator.init(new KDFCounterParameters(sessionKey.getEncoded(), null, fixedSuffix, KDF_R_VALUE));
+        byte[] generatedKey = new byte[KDF_L_VALUE];
+        kdfGenerator.generateBytes(generatedKey, 0, KDF_L_VALUE);
+
+        // return the generatedKey with assigning the algorithm (for the key to to be used)
+        return new SecretKeySpec(generatedKey, algorithm);
+    }
+}

--- a/src/main/java/com/hierynomus/security/DecryptPacketInfo.java
+++ b/src/main/java/com/hierynomus/security/DecryptPacketInfo.java
@@ -15,12 +15,24 @@
  */
 package com.hierynomus.security;
 
-public interface MessageDigest {
-    void update(byte[] bytes);
+import com.hierynomus.mssmb2.Smb2EncryptionCipher;
 
-    byte[] digest();
+import javax.crypto.spec.SecretKeySpec;
 
-    void reset();
+public class DecryptPacketInfo {
+    private final SecretKeySpec decryptionKey;
+    private final Smb2EncryptionCipher algorithm;
 
-    int getDigestLength();
+    public DecryptPacketInfo(SecretKeySpec decryptionKey, Smb2EncryptionCipher algorithm) {
+        this.decryptionKey = decryptionKey;
+        this.algorithm = algorithm;
+    }
+
+    public SecretKeySpec getDecryptionKey() {
+        return decryptionKey;
+    }
+
+    public Smb2EncryptionCipher getAlgorithm() {
+        return algorithm;
+    }
 }

--- a/src/main/java/com/hierynomus/security/DigestUtil.java
+++ b/src/main/java/com/hierynomus/security/DigestUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.security;
+
+import com.hierynomus.mssmb.SMB1Packet;
+import com.hierynomus.mssmb2.SMB2Packet;
+import com.hierynomus.smb.SMBBuffer;
+import com.hierynomus.smb.SMBPacket;
+
+public class DigestUtil {
+    public static byte[] concatenatePreviousUpdateDigest(MessageDigest messageDigest, byte[] previousBytes, byte[] updateBytes) {
+        messageDigest.update(previousBytes);
+        messageDigest.update(updateBytes);
+        return messageDigest.digest();
+    }
+
+    public static byte[] getRequestPacketBytes(SMBPacket request) {
+        if (request == null) {
+            throw new IllegalStateException("passing null to getRequestPacketBytes method");
+        }
+
+        SMBBuffer buffer = new SMBBuffer();
+
+        if (request instanceof SMB2Packet) {
+            SMB2Packet smb2Packet = ((SMB2Packet) request);
+            smb2Packet.write(buffer);
+        } else if(request instanceof SMB1Packet) {
+            // also handle for the SMB1ComNegotiateRequest packet case
+            SMB1Packet smb1Packet = (SMB1Packet)request;
+            smb1Packet.write(buffer);
+        } else {
+            throw new IllegalStateException("passing unknown request packet to getRequestPacketBytes method");
+        }
+
+        return buffer.getCompactData();
+    }
+
+    public static byte[] getResponsePacketBytes(SMB2Packet response) {
+        if (response == null) {
+            throw new IllegalStateException("passing null to getResponsePacketBytes method");
+        }
+
+        // extract the context bytes
+        SMBBuffer responseBuffer = response.getBuffer();
+        // record the original read position
+        int originalPos = responseBuffer.rpos();
+        // seek to 0 and get whole response bytes
+        responseBuffer.rpos(0);
+        byte[] responseBytes = responseBuffer.getCompactData();
+        // seek back to original read position
+        responseBuffer.rpos(originalPos);
+
+        return responseBytes;
+    }
+}

--- a/src/main/java/com/hierynomus/security/SecurityProvider.java
+++ b/src/main/java/com/hierynomus/security/SecurityProvider.java
@@ -33,4 +33,6 @@ public interface SecurityProvider {
     Mac getMac(String name) throws SecurityException;
 
     Cipher getCipher(String name) throws SecurityException;
+
+    AEADBlockCipher getAEADBlockCipher(String name) throws SecurityException;
 }

--- a/src/main/java/com/hierynomus/security/bc/BCAEADBlockCipherFactory.java
+++ b/src/main/java/com/hierynomus/security/bc/BCAEADBlockCipherFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.security.bc;
+
+import com.hierynomus.protocol.commons.Factory;
+import com.hierynomus.security.AEADBlockCipher;
+import com.hierynomus.security.Cipher.CryptMode;
+import com.hierynomus.security.SecurityException;
+
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.modes.CCMBlockCipher;
+import org.bouncycastle.crypto.modes.GCMBlockCipher;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.spec.GCMParameterSpec;
+
+public class BCAEADBlockCipherFactory {
+    private static final Map<String, Factory<AEADBlockCipher>> lookup = new HashMap<>();
+
+    static {
+        lookup.put("AES/CCM/NoPadding", new Factory<AEADBlockCipher>() {
+            @Override
+            public AEADBlockCipher create() {
+                return new BCAEADBlockCipher(new CCMBlockCipher(new AESEngine())) {
+                    @Override
+                    protected CipherParameters createParams(byte[] key,
+                                                            GCMParameterSpec gcmParameterSpec) {
+                        return new AEADParameters(
+                            new KeyParameter(key),
+                            gcmParameterSpec.getTLen(),
+                            gcmParameterSpec.getIV()
+                        );
+                    }
+                };
+            }
+        });
+        lookup.put("AES/GCM/NoPadding", new Factory<AEADBlockCipher>() {
+            @Override
+            public AEADBlockCipher create() {
+                return new BCAEADBlockCipher(new GCMBlockCipher(new AESEngine())) {
+                    @Override
+                    protected CipherParameters createParams(byte[] key,
+                                                            GCMParameterSpec gcmParameterSpec) {
+                        return new AEADParameters(
+                            new KeyParameter(key),
+                            gcmParameterSpec.getTLen(),
+                            gcmParameterSpec.getIV()
+                        );
+                    }
+                };
+            }
+        });
+    }
+
+    public static AEADBlockCipher create(String name) {
+        Factory<AEADBlockCipher> cipherFactory = lookup.get(name);
+        if (cipherFactory == null) {
+            throw new IllegalArgumentException("Unknown AEADCipher " + name);
+        }
+        return cipherFactory.create();
+    }
+
+    private static abstract class BCAEADBlockCipher implements AEADBlockCipher {
+        private org.bouncycastle.crypto.modes.AEADBlockCipher wrappedCipher;
+
+        BCAEADBlockCipher(org.bouncycastle.crypto.modes.AEADBlockCipher aeadBlockCipher) {
+            this.wrappedCipher = aeadBlockCipher;
+        }
+
+        @Override
+        public void init(CryptMode cryptMode, byte[] bytes, GCMParameterSpec gcmParameterSpec) throws SecurityException {
+            wrappedCipher.init(cryptMode == CryptMode.ENCRYPT, createParams(bytes, gcmParameterSpec));
+        }
+
+        @Override
+        public void updateAAD(byte[] aad, int aadOffset, int aadLength) throws SecurityException {
+            wrappedCipher.processAADBytes(aad, aadOffset, aadLength);
+        }
+
+        @Override
+        public byte[] update(byte[] in, int inOffset, int inLength) throws SecurityException {
+            int outputSize = wrappedCipher.getUpdateOutputSize(inLength);
+            byte[] out = new byte[outputSize];
+            wrappedCipher.processBytes(in, inOffset, inLength, out, 0);
+            return out;
+        }
+
+        @Override
+        public byte[] doFinal(byte[] in, int inOffset, int inLength) throws SecurityException {
+            int outOff = 0;
+            int outputSizeWithFinal = wrappedCipher.getOutputSize(inLength);
+            byte[] out = new byte[outputSizeWithFinal];
+            outOff += wrappedCipher.processBytes(in, inOffset, inLength, out, outOff);
+            try {
+                outOff += wrappedCipher.doFinal(out, outOff);
+            } catch (InvalidCipherTextException e) {
+                throw new SecurityException(e);
+            }
+            return out;
+        }
+
+        @Override
+        public void reset() {
+            wrappedCipher.reset();
+        }
+
+        protected abstract CipherParameters createParams(byte[] key, GCMParameterSpec gcmParameterSpec);
+    }
+}

--- a/src/main/java/com/hierynomus/security/bc/BCMac.java
+++ b/src/main/java/com/hierynomus/security/bc/BCMac.java
@@ -19,6 +19,8 @@ import com.hierynomus.protocol.commons.Factory;
 import com.hierynomus.security.Mac;
 import org.bouncycastle.crypto.digests.MD5Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.macs.CMac;
 import org.bouncycastle.crypto.macs.HMac;
 import org.bouncycastle.crypto.params.KeyParameter;
 
@@ -41,6 +43,13 @@ public class BCMac implements Mac {
                 return new HMac(new MD5Digest());
             }
         });
+        lookup.put("AESCMAC", new Factory<org.bouncycastle.crypto.Mac>() {
+            @Override
+            public org.bouncycastle.crypto.Mac create() {
+                return new CMac(new AESEngine());
+            }
+        });
+
     }
 
     private final org.bouncycastle.crypto.Mac mac;

--- a/src/main/java/com/hierynomus/security/bc/BCMessageDigest.java
+++ b/src/main/java/com/hierynomus/security/bc/BCMessageDigest.java
@@ -20,6 +20,7 @@ import com.hierynomus.security.MessageDigest;
 import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.digests.MD4Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.digests.SHA512Digest;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +29,12 @@ public class BCMessageDigest implements MessageDigest {
     private static Map<String, Factory<Digest>> lookup = new HashMap<>();
 
     static {
+        lookup.put("SHA-512", new Factory<Digest>() {
+            @Override
+            public Digest create() {
+                return new SHA512Digest();
+            }
+        });
         lookup.put("SHA256", new Factory<Digest>() {
             @Override
             public Digest create() {
@@ -71,5 +78,10 @@ public class BCMessageDigest implements MessageDigest {
     @Override
     public void reset() {
         digest.reset();
+    }
+
+    @Override
+    public int getDigestLength() {
+        return digest.getDigestSize();
     }
 }

--- a/src/main/java/com/hierynomus/security/bc/BCSecurityProvider.java
+++ b/src/main/java/com/hierynomus/security/bc/BCSecurityProvider.java
@@ -38,4 +38,9 @@ public class BCSecurityProvider implements SecurityProvider {
     public Cipher getCipher(String name) {
         return BCCipherFactory.create(name);
     }
+
+    @Override
+    public AEADBlockCipher getAEADBlockCipher(String name) throws SecurityException {
+        return BCAEADBlockCipherFactory.create(name);
+    }
 }

--- a/src/main/java/com/hierynomus/security/jce/JceAEADCipher.java
+++ b/src/main/java/com/hierynomus/security/jce/JceAEADCipher.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.security.jce;
+
+import com.hierynomus.security.AEADBlockCipher;
+import com.hierynomus.security.Cipher.CryptMode;
+import com.hierynomus.security.SecurityException;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class JceAEADCipher implements AEADBlockCipher {
+    private javax.crypto.Cipher cipher;
+
+    JceAEADCipher(String name, Provider jceProvider, String providerName) throws SecurityException {
+        try {
+            if (jceProvider != null) {
+                this.cipher = javax.crypto.Cipher.getInstance(name, jceProvider);
+            } else if (providerName != null) {
+                this.cipher = javax.crypto.Cipher.getInstance(name, providerName);
+            } else {
+                this.cipher = javax.crypto.Cipher.getInstance(name);
+            }
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | NoSuchProviderException e) {
+            throw new SecurityException(e);
+        }
+    }
+
+    @Override
+    public void init(CryptMode cryptMode, byte[] bytes, GCMParameterSpec gcmParameterSpec) throws SecurityException {
+        try {
+            if (CryptMode.DECRYPT == cryptMode) {
+                cipher.init(javax.crypto.Cipher.DECRYPT_MODE, new SecretKeySpec(bytes, cipher.getAlgorithm().split("/")[0]), gcmParameterSpec);
+            } else {
+                cipher.init(javax.crypto.Cipher.ENCRYPT_MODE, new SecretKeySpec(bytes, cipher.getAlgorithm().split("/")[0]), gcmParameterSpec);
+            }
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw new SecurityException(e);
+        }
+    }
+
+    @Override
+    public void updateAAD(byte[] aad, int aadOffset, int aadLength) throws SecurityException {
+        cipher.updateAAD(aad, aadOffset, aadLength);
+    }
+
+    @Override
+    public byte[] update(byte[] in, int inOffset, int inLength) throws SecurityException {
+        return cipher.update(in, inOffset, inLength);
+    }
+
+    @Override
+    public byte[] doFinal(byte[] in, int inOffset, int inLength) throws SecurityException {
+        try {
+            return cipher.doFinal(in, inOffset, inLength);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new SecurityException(e);
+        }
+    }
+
+    @Override
+    public void reset() {
+        // no-op
+    }
+}

--- a/src/main/java/com/hierynomus/security/jce/JceMessageDigest.java
+++ b/src/main/java/com/hierynomus/security/jce/JceMessageDigest.java
@@ -74,4 +74,9 @@ public class JceMessageDigest implements MessageDigest {
     public void reset() {
         md.reset();
     }
+
+    @Override
+    public int getDigestLength() {
+        return md.getDigestLength();
+    }
 }

--- a/src/main/java/com/hierynomus/security/jce/JceSecurityProvider.java
+++ b/src/main/java/com/hierynomus/security/jce/JceSecurityProvider.java
@@ -53,4 +53,9 @@ public class JceSecurityProvider implements SecurityProvider {
     public Cipher getCipher(String name) throws SecurityException {
         return new JceCipher(name, jceProvider, providerName);
     }
+
+    @Override
+    public AEADBlockCipher getAEADBlockCipher(String name) throws SecurityException{
+        return new JceAEADCipher(name, jceProvider, providerName);
+    }
 }

--- a/src/main/java/com/hierynomus/smbj/session/PacketEncryptor.java
+++ b/src/main/java/com/hierynomus/smbj/session/PacketEncryptor.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.smbj.session;
+
+import com.hierynomus.mssmb2.SMB2Dialect;
+import com.hierynomus.mssmb2.SMB2Header;
+import com.hierynomus.mssmb2.SMB2Packet;
+import com.hierynomus.mssmb2.SMB2TransformHeaderFunctions;
+import com.hierynomus.mssmb2.Smb2EncryptionCipher;
+import com.hierynomus.security.AEADBlockCipher;
+import com.hierynomus.security.Cipher.CryptMode;
+import com.hierynomus.security.CryptographicKeysGenerator;
+import com.hierynomus.security.SecurityProvider;
+import com.hierynomus.security.SecurityException;
+import com.hierynomus.smb.SMBBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.security.Key;
+
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class PacketEncryptor {
+    private static final Logger logger = LoggerFactory.getLogger(PacketEncryptor.class);
+
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- ProtocolId (4 bytes)
+    private static final byte[] SMB2_TRANSFORM_HEADER_PROTOCOL_ID = SMB2TransformHeaderFunctions.SMB2_TRANSFORM_HEADER_PROTOCOL_ID;
+    // RFC 5116  section 5.1 and 5.3, https://tools.ietf.org/html/rfc5116#section-5.1
+    private static final int AUTHENTICATION_TAG_LENGTH = SMB2TransformHeaderFunctions.AUTHENTICATION_TAG_LENGTH; // authentication tag with a length of 16 octets (128bits) is used
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- Nonce (16 bytes)
+    private static final int AES128CCM_NONCE_LENGTH = SMB2TransformHeaderFunctions.AES128CCM_NONCE_LENGTH;
+    private static final int AES128GCM_NONCE_LENGTH = SMB2TransformHeaderFunctions.AES128GCM_NONCE_LENGTH;
+
+    private SMB2Dialect dialect;
+    private final Smb2EncryptionCipher algorithm;
+    private SecurityProvider securityProvider;
+    private Key sessionKey = null;
+    private Key encryptionKey = null;
+    private Key decryptionKey = null;
+    private BigInteger nonceCounter = BigInteger.ZERO;
+
+    PacketEncryptor(SMB2Dialect dialect, SecurityProvider securityProvider, Smb2EncryptionCipher algorithm) {
+        this.dialect = dialect;
+        this.securityProvider = securityProvider;
+        this.algorithm = algorithm;
+    }
+
+    void init(byte[] sessionKey) {
+        init(sessionKey, null);
+    }
+
+    void init(byte[] sessionKey, byte[] sessionPreauthIntegrityHashValue) {
+        if (dialect.isSmb3x()) {
+            if (algorithm == null) {
+                throw new IllegalStateException("Encryption algorithm is null when initializing PacketEncryptor");
+            }
+            if (sessionKey != null) {
+                this.sessionKey = new SecretKeySpec(sessionKey, "");
+                if (dialect == SMB2Dialect.SMB_3_1_1) {
+                    if (sessionPreauthIntegrityHashValue == null) {
+                        // dialect 3.1.1 with null for sessionPreauthIntegrityHashValue case,
+
+                        logger.error("sessionPreauthIntegrityHashValue is null when generating encryption key for SMB3.1.1");
+                        throw new IllegalStateException("sessionPreauthIntegrityHashValue is null when generating encryption key for SMB3.1.1");
+                    }
+
+                    // dialect 3.1.1 with non-null value for sessionPreauthIntegrityHashValue case,
+
+                    this.encryptionKey = CryptographicKeysGenerator.generateKey(
+                        this.sessionKey,
+                        CryptographicKeysGenerator.Smb311EncryptLabelByteArray,
+                        sessionPreauthIntegrityHashValue,
+                        algorithm.getAlgorithmName()
+                    );
+                    this.decryptionKey = CryptographicKeysGenerator.generateKey(
+                        this.sessionKey,
+                        CryptographicKeysGenerator.Smb311DecryptLabelByteArray,
+                        sessionPreauthIntegrityHashValue,
+                        algorithm.getAlgorithmName()
+                    );
+                } else {
+                    // remaining dialect 3.0.x case,
+
+                    this.encryptionKey = CryptographicKeysGenerator.generateKey(
+                        this.sessionKey,
+                        CryptographicKeysGenerator.Smb30xEncryptLabelByteArray,
+                        CryptographicKeysGenerator.Smb30xEncryptContextByteArray,
+                        algorithm.getAlgorithmName()
+                    );
+                    this.decryptionKey = CryptographicKeysGenerator.generateKey(
+                        this.sessionKey,
+                        CryptographicKeysGenerator.Smb30xDecryptLabelByteArray,
+                        CryptographicKeysGenerator.Smb30xDecryptContextByteArray,
+                        algorithm.getAlgorithmName()
+                    );
+                }
+            } else {
+                // TODO throw Error?
+                this.sessionKey = null;
+                this.encryptionKey = null;
+                this.decryptionKey = null;
+            }
+        } else {
+            throw new IllegalStateException("Encryption is not supported for SMB2.x family");
+        }
+    }
+
+    boolean isInitialized() {
+        return sessionKey != null && encryptionKey != null && decryptionKey != null;
+    }
+
+    SMB2Packet encrypt(SMB2Packet packet) {
+        if (isInitialized()) {
+            return new EncryptedPacketWrapper(packet);
+        } else {
+            logger.debug("Not wrapping {} as encrypted, as no key is set.", packet.getHeader().getMessage());
+            return packet;
+        }
+    }
+
+    private byte[] getNewNonceField() {
+        byte[] nonce; // Nonce is always 16 bytes in SMB2_TRANSFORM_HEADER
+        byte[] nonceCounterArray = nonceCounter.toByteArray();
+        // increment the nonceCounter
+        nonceCounter = nonceCounter.add(BigInteger.ONE);
+
+        // Base on the selected algorithm, generate the nonce.
+        switch (algorithm) {
+            case AES_128_CCM: {
+                nonce = privateStaticGetNonce(nonceCounterArray, AES128CCM_NONCE_LENGTH);
+                break;
+            }
+            case AES_128_GCM: {
+                nonce = privateStaticGetNonce(nonceCounterArray, AES128GCM_NONCE_LENGTH);
+                break;
+            }
+            default:
+                throw new IllegalStateException("Unknown encryption algorithm (not supported) when generating new nonce.");
+        }
+
+        return nonce;
+    }
+
+    private static byte[] privateStaticGetNonce(byte[] nonceCounterArray, final int nonceLength) {
+        SMBBuffer buffer = new SMBBuffer();
+        if (nonceCounterArray.length < nonceLength) {
+            int addingZeros = nonceLength - nonceCounterArray.length;
+            // since nonceCounterArray.length < nonceLength, it will be fine.
+            // Using the less significant bit first.
+            for (int i = 0; i < nonceCounterArray.length; i++) {
+                int index = nonceCounterArray.length - 1 - i;
+                buffer.putByte(nonceCounterArray[index]);
+            }
+            buffer.putReserved(addingZeros);
+        } else {
+            // Using the less significant bit first.
+            for (int i = 0; i < nonceLength; i++) {
+                int index = nonceCounterArray.length - 1 - i;
+                buffer.putByte(nonceCounterArray[index]);
+            }
+        }
+        // Reserved (4 bytes for AES128CCM, 5 bytes for AES128GCM)
+        buffer.putReserved(16 - nonceLength);
+
+        return buffer.getCompactData();
+    }
+
+    private byte[] privateEncrypt(byte[] plainText, byte[] aad, GCMParameterSpec parameterSpec)
+        throws SecurityException {
+        byte[] cipherText;
+        try {
+            AEADBlockCipher aeadBlockCipher = securityProvider.getAEADBlockCipher(algorithm.getAlgorithmName());
+            aeadBlockCipher.init(CryptMode.ENCRYPT, encryptionKey.getEncoded(), parameterSpec);
+            aeadBlockCipher.updateAAD(aad, 0, aad.length);
+            cipherText = aeadBlockCipher.doFinal(plainText, 0, plainText.length);
+        } catch (SecurityException e) {
+            logger.error("Unable to encrypt message, error occur : ", e);
+            throw e;
+        }
+        return cipherText;
+    }
+
+    public class EncryptedPacketWrapper extends SMB2Packet {
+        private final SMB2Packet wrappedPacket;
+
+        EncryptedPacketWrapper(SMB2Packet packet) {
+            this.wrappedPacket = packet;
+        }
+
+        @Override
+        public int getMaxPayloadSize() {
+            return wrappedPacket.getMaxPayloadSize();
+        }
+
+        @Override
+        public void write(SMBBuffer buffer) {
+            // 3.2.4.1.1 Signing the Message,
+            // If the client encrypts the message, as specified in section 3.1.4.3,
+            // then the client MUST set the Signature field of the SMB2 header to zero.
+            // Checked with Windows 10 Client behaviour, should NOT set SMB2_FLAGS_SIGNED as well.
+
+            SMBBuffer plainTextBuffer = new SMBBuffer();
+            // Write the whole plainText packet to the buffer
+            wrappedPacket.write(plainTextBuffer);
+            // number of bytes available to read is equals to packet size
+            final int plainTextSize = plainTextBuffer.available();
+            final byte[] plainText = plainTextBuffer.getCompactData();
+
+            if (plainText.length != plainTextSize) {
+                // TODO throw exception?
+                logger.debug("plainText.length != plainTextSize");
+            }
+
+            // The nonce used in the SMB2_TRANSFORM_HEADER
+            final byte[] nonceField = getNewNonceField();
+            // the nonce actually used in encryption
+            final byte[] nonce = SMB2TransformHeaderFunctions.getActualNonce(algorithm, nonceField);
+            final GCMParameterSpec parameterSpec = new GCMParameterSpec(128, nonce);
+
+            // 3.1.4.3 Encrypting the Message, The SMB2 TRANSFORM_HEADER,
+            // excluding the ProtocolId and Signature fields,
+            // as the optional authenticated data.
+            final byte[] aad = SMB2TransformHeaderFunctions.newAAD(nonceField, plainTextSize, wrappedPacket.getHeader().getSessionId());
+
+            // the AEC-CCM and AES-GCM both will generate cipherText with authentication tag
+            byte[] cipherTextWithMac;
+            try {
+                cipherTextWithMac = privateEncrypt(plainText, aad, parameterSpec);
+            } catch (SecurityException e) {
+                // TODO Handle the exception properly
+                throw new IllegalStateException(e);
+            }
+            // the plainTextSize should equals cipherTextSize - AUTHENTICATION_TAG_LENGTH
+            if (cipherTextWithMac.length != plainTextSize + AUTHENTICATION_TAG_LENGTH) {
+                throw new IllegalStateException("Invalid length for cipherText after encryption.");
+            }
+
+            // Actual Writing the Packet with SMB2_TRANSFORM_HEADER
+            buffer.putRawBytes(SMB2_TRANSFORM_HEADER_PROTOCOL_ID); // ProtocolId (4 bytes)
+            buffer.putRawBytes(cipherTextWithMac, plainTextSize, AUTHENTICATION_TAG_LENGTH); // Signature (16 bytes)
+            buffer.putRawBytes(aad); // Nonce (16 bytes), OriginalMessageSize (4 bytes), Reserved (2 bytes), Flags/EncryptionAlgorithm (2 bytes), SessionId (8 bytes)
+            buffer.putRawBytes(cipherTextWithMac, 0, plainTextSize); // encrypted packet (variable)
+        }
+
+        @Override
+        public SMB2Header getHeader() {
+            return wrappedPacket.getHeader();
+        }
+
+        // TODO do we need to override this function?
+        @Override
+        public long getSequenceNumber() {
+            return wrappedPacket.getSequenceNumber();
+        }
+
+        // TODO do we need to override this function?
+        @Override
+        public int getStructureSize() {
+            return wrappedPacket.getStructureSize();
+        }
+
+        @Override
+        public String toString() {
+            return wrappedPacket.toString();
+        }
+
+        /**
+         * Return the result of the {@link #getPacket()} call on the wrapped packet.
+         * @return The unwrapped wrapppedPacket
+         */
+        @Override
+        public SMB2Packet getPacket() {
+            return wrappedPacket.getPacket();
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/smbj/share/Share.java
+++ b/src/main/java/com/hierynomus/smbj/share/Share.java
@@ -351,6 +351,10 @@ public class Share implements AutoCloseable {
             throw new SMBRuntimeException(getClass().getSimpleName() + " has already been closed");
         }
 
+        if (treeConnect.isEncryptData() || session.isEncryptData() || session.getConnection().isClientDecidedEncrypt()) {
+            request.setRequireEncrypt(true);
+        }
+
         try {
             return session.send(request);
         } catch (TransportException e) {

--- a/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
+++ b/src/main/java/com/hierynomus/smbj/share/TreeConnect.java
@@ -20,6 +20,7 @@ import com.hierynomus.mserref.NtStatus;
 import com.hierynomus.mssmb2.SMB2Packet;
 import com.hierynomus.mssmb2.SMB2ShareCapabilities;
 import com.hierynomus.mssmb2.SMBApiException;
+import com.hierynomus.mssmb2.SMB2ShareFlags;
 import com.hierynomus.mssmb2.messages.SMB2TreeDisconnect;
 import com.hierynomus.protocol.commons.concurrent.Futures;
 import com.hierynomus.protocol.transport.TransportException;
@@ -29,6 +30,7 @@ import com.hierynomus.smbj.event.SMBEventBus;
 import com.hierynomus.smbj.event.TreeDisconnected;
 import com.hierynomus.smbj.session.Session;
 
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -41,19 +43,33 @@ public class TreeConnect {
     private long treeId;
     private SmbPath smbPath;
     private Session session;
+    private final Set<SMB2ShareFlags> shareFlags;
     private final Set<SMB2ShareCapabilities> capabilities;
     private Connection connection;
     private final SMBEventBus bus;
     private final Set<AccessMask> maximalAccess;
+    private boolean encryptData; // SMB3.x
 
-    public TreeConnect(long treeId, SmbPath smbPath, Session session, Set<SMB2ShareCapabilities> capabilities, Connection connection, SMBEventBus bus, Set<AccessMask> maximalAccess) {
+    @Deprecated
+    public TreeConnect(long treeId, SmbPath smbPath, Session session, Set<SMB2ShareCapabilities> capabilities, Connection connection, SMBEventBus connectionPrivateBus, Set<AccessMask> maximalAccess) {
+        this(treeId, smbPath, session, capabilities, connection, connectionPrivateBus, maximalAccess, EnumSet.noneOf(SMB2ShareFlags.class));
+    }
+
+    public TreeConnect(long treeId, SmbPath smbPath, Session session, Set<SMB2ShareCapabilities> capabilities, Connection connection, SMBEventBus bus, Set<AccessMask> maximalAccess, Set<SMB2ShareFlags> shareFlags) {
         this.treeId = treeId;
         this.smbPath = smbPath;
         this.session = session;
+        this.shareFlags = shareFlags;
         this.capabilities = capabilities;
         this.connection = connection;
         this.bus = bus;
         this.maximalAccess = maximalAccess;
+        // 3.2.5.5 Receiving an SMB2 TREE_CONNECT Response, TreeConnect.EncryptData
+        if (connection.getNegotiatedProtocol().getDialect().isSmb3x()
+            && connection.getConnectionInfo().isConnectionSupportEncrypt()
+            && shareFlags.contains(SMB2ShareFlags.SMB2_SHAREFLAG_ENCRYPT_DATA)) {
+            encryptData = true;
+        }
     }
 
     Connection getConnection() {
@@ -63,7 +79,7 @@ public class TreeConnect {
     void close() throws TransportException {
         try {
             SMB2TreeDisconnect disconnect = new SMB2TreeDisconnect(connection.getNegotiatedProtocol().getDialect(), session.getSessionId(), treeId);
-            Future<SMB2Packet> send = session.send(disconnect);
+            Future<SMB2Packet> send = sendBySession(disconnect);
             SMB2Packet smb2Packet = Futures.get(send, connection.getConfig().getTransactTimeout(), TimeUnit.MILLISECONDS, TransportException.Wrapper);
             if (!NtStatus.isSuccess(smb2Packet.getHeader().getStatusCode())) {
                 throw new SMBApiException(smb2Packet.getHeader(), "Error closing connection to " + smbPath);
@@ -89,6 +105,10 @@ public class TreeConnect {
         return maximalAccess;
     }
 
+    public Set<SMB2ShareFlags> getShareFlags() {
+        return shareFlags;
+    }
+
     public boolean isDfsShare() {
         return capabilities.contains(SMB2ShareCapabilities.SMB2_SHARE_CAP_DFS);
     }
@@ -99,6 +119,25 @@ public class TreeConnect {
 
     public boolean isScaleoutShare() {
         return capabilities.contains(SMB2ShareCapabilities.SMB2_SHARE_CAP_SCALEOUT);
+    }
+
+    public boolean isEncryptData() {
+        return encryptData;
+    }
+
+    /***
+     * Send the packet by session with ensure the packet will correctly handle the encryption part if needed
+     *
+     * @param packet SMBPacket to send
+     * @param <T> the response packet to the packet you send
+     * @return a Future to be used to retrieve the response packet
+     * @throws TransportException
+     */
+    private <T extends SMB2Packet> Future<T> sendBySession(SMB2Packet packet) throws TransportException {
+        if (encryptData || session.isEncryptData() || connection.isClientDecidedEncrypt()) {
+            packet.setRequireEncrypt(true);
+        }
+        return session.send(packet);
     }
 
     @Override

--- a/src/test/groovy/com/hierynomus/mssmb2/SMB2TransformHeaderFunctionsSpec.groovy
+++ b/src/test/groovy/com/hierynomus/mssmb2/SMB2TransformHeaderFunctionsSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2
+
+import spock.lang.Specification
+
+class SMB2TransformHeaderFunctionsSpec extends Specification {
+
+  def "should have correct Smb2TransformHeaderProtocolId"() {
+    given:
+    // groovy version of java's new byte[]{(byte) 0xFD, 'S', 'M', 'B'}
+    byte[] transformHeaderProtocolId = [(byte) 0xFD, (byte) 0x53, (byte) 0x4D, (byte) 0x42] as byte[]
+
+    when:
+    byte[] receviedProtocolId = SMB2TransformHeaderFunctions.SMB2_TRANSFORM_HEADER_PROTOCOL_ID
+
+    then:
+    Arrays.equals(transformHeaderProtocolId, receviedProtocolId)
+  }
+
+  def "should able to form the aad correctly"() {
+    given:
+    byte[] expectedAAD = [
+      // Nonce (16 bytes)
+      (byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+      // OriginalMessageSize (4 bytes)
+      (byte) 0x10, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+      // Reserved (2 bytes)
+      (byte) 0x0, (byte) 0x0,
+      // Flags/EncryptionAlgorithm (2 bytes)
+      (byte) 0x01, (byte) 0x0,
+      // SessionId (8 bytes)
+      (byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0
+    ] as byte[]
+    byte[] nonceField = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    int originalMessageSize = 16
+    long sessionId = 1
+
+    when:
+    byte[] aad = SMB2TransformHeaderFunctions.newAAD(nonceField, originalMessageSize, sessionId)
+
+    then:
+    Arrays.equals(aad, expectedAAD)
+  }
+
+  def "should able to get actual nonce for AES-CCM correctly"() {
+    given:
+    byte[] nonceField = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    byte[] expectedActualNonce = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    Smb2EncryptionCipher algorithm = Smb2EncryptionCipher.AES_128_CCM
+
+    when:
+    byte[] nonce = SMB2TransformHeaderFunctions.getActualNonce(algorithm, nonceField)
+
+    then:
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- Nonce (16 bytes)
+    // public static final int AES128CCM_NONCE_LENGTH = 11;
+    nonce.length == 11
+    Arrays.equals(nonce, expectedActualNonce)
+  }
+
+  def "should able to get actual nonce for AES-GCM correctly"() {
+    given:
+    byte[] nonceField = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    byte[] expectedActualNonce = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    Smb2EncryptionCipher algorithm = Smb2EncryptionCipher.AES_128_GCM
+
+    when:
+    byte[] nonce = SMB2TransformHeaderFunctions.getActualNonce(algorithm, nonceField)
+
+    then:
+    // 2.2.41 SMB2 TRANSFORM_HEADER -- Nonce (16 bytes)
+    // public static final int AES128GCM_NONCE_LENGTH = 12;
+    nonce.length == 12
+    Arrays.equals(nonce, expectedActualNonce)
+  }
+}

--- a/src/test/groovy/com/hierynomus/mssmb2/SMB3EncryptedPacketFactorySpec.groovy
+++ b/src/test/groovy/com/hierynomus/mssmb2/SMB3EncryptedPacketFactorySpec.groovy
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.mssmb2
+
+import com.hierynomus.msdtyp.FileTime
+import com.hierynomus.msdtyp.MsDataTypes
+import com.hierynomus.mserref.NtStatus
+import com.hierynomus.msfscc.FileAttributes
+import com.hierynomus.mssmb2.SMB2CreateAction
+import com.hierynomus.mssmb2.SMB2FileId
+import com.hierynomus.mssmb2.SMB2Header
+import com.hierynomus.mssmb2.SMB2MessageCommandCode
+import com.hierynomus.mssmb2.SMB2MessageFlag
+import com.hierynomus.mssmb2.SMB2Packet
+import com.hierynomus.mssmb2.SMB2TransformHeaderFunctions
+import com.hierynomus.mssmb2.Smb2EncryptionCipher
+import com.hierynomus.mssmb2.messages.SMB2CreateRequest
+import com.hierynomus.mssmb2.messages.SMB2CreateResponse
+import com.hierynomus.protocol.commons.ByteArrayUtils
+import com.hierynomus.protocol.commons.EnumWithValue
+import com.hierynomus.security.DecryptPacketInfo
+import com.hierynomus.security.bc.BCSecurityProvider
+import com.hierynomus.smb.SMBBuffer
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import spock.lang.Specification
+
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class SMB3EncryptedPacketFactorySpec extends Specification {
+
+  // groovy version of java's new byte[]{(byte) 0xFE, 'S', 'M', 'B'}
+  byte[] smb2HeaderProtocolId = [(byte) 0xFE, (byte) 0x53, (byte) 0x4D, (byte) 0x42] as byte[]
+  // groovy version of java's new byte[]{(byte) 0xFD, 'S', 'M', 'B'}
+  byte[] transformHeaderProtocolId = [(byte) 0xFD, (byte) 0x53, (byte) 0x4D, (byte) 0x42] as byte[]
+
+  def sessionKey = ByteArrayUtils.parseHex("09921d4431b171b977370bf8910900f9")
+  def smb30xExpectedSigningKey = ByteArrayUtils.parseHex("8f5a6907bce9ec89b8f89e560d4e2e18")
+  def smb30xExpectedEncryptionKey = ByteArrayUtils.parseHex("858e8cba1f7068969e825b2b538830c4")
+  def smb30xExpectedDecryptionKey = ByteArrayUtils.parseHex("df91d31ef09a01fd4d2a093c42deef46")
+  def javaBCProvider = new BouncyCastleProvider()
+  def smbjBCProvider = new BCSecurityProvider()
+  def smb2PacketFactory = new SMB2PacketFactory()
+  def smb2MessageConverter = new SMB2MessageConverter()
+
+  def "should able to decrypt a message correctly for AES-CCM"() {
+    given:
+    int creditCharge = 1
+    int creditResponse = 1
+    long sessionId = 1L
+    int treeId = 1
+    long messageId = 4L
+    int headerStructureSize = 64
+    long headerFlags = SMB2MessageFlag.SMB2_FLAGS_SIGNED.value
+    SMB2MessageCommandCode command = SMB2MessageCommandCode.SMB2_CREATE
+    NtStatus status = NtStatus.STATUS_SUCCESS
+    int createResponseStructureSize = 89
+    byte oplockLevel = 0x0 // SMB2OplockLevel.SMB2_OPLOCK_LEVEL_NONE
+    SMB2CreateAction createAction = SMB2CreateAction.FILE_OPENED
+    long allocationSize = 4096L
+    int endOfFile = 16
+    Set<FileAttributes> fileAttributes = EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL)
+    FileTime fileTime = FileTime.now()
+    SMB2FileId fileId = new SMB2FileId()
+    // the given parameter
+    SMB3EncryptedPacketFactory converter = new SMB3EncryptedPacketFactory(smb2PacketFactory, smbjBCProvider)
+    Smb2EncryptionCipher algorithm = Smb2EncryptionCipher.AES_128_CCM
+    byte[] nonceField = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    byte[] nonce = [(byte) 0x01, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0] as byte[]
+    int authenticationTagLength = SMB2TransformHeaderFunctions.AUTHENTICATION_TAG_LENGTH
+
+
+    when:
+    // Form the sample createResponse to byte[] to encrypt as encrypted message to test the converter decryption
+    // write the header to the plainText buffer
+    SMBBuffer plainTextBuffer = new SMBBuffer()
+    plainTextBuffer.putRawBytes(smb2HeaderProtocolId) // ProtocolId (4 bytes)
+    plainTextBuffer.putUInt16(headerStructureSize) // StructureSize (2 bytes)
+    plainTextBuffer.putUInt16(creditCharge) // CreditCharge (2 bytes)
+    plainTextBuffer.putUInt32(status.value) // Status (4 bytes)
+    plainTextBuffer.putUInt16(command.value) // Command (2 bytes)
+    plainTextBuffer.putUInt16(creditResponse) // CreditRequest/CreditResponse (2 bytes)
+    plainTextBuffer.putUInt32(headerFlags) // Flags (4 bytes)
+    plainTextBuffer.putUInt32(0) // NextCommand (4 bytes)
+    plainTextBuffer.putLong(messageId) // MessageId (8 bytes)
+    plainTextBuffer.putReserved4() // Reserved (4 bytes)
+    plainTextBuffer.putUInt32(treeId) // TreeId (4 bytes)
+    plainTextBuffer.putLong(sessionId) // SessionId (8 bytes)
+    plainTextBuffer.putRawBytes(new byte[16]) // Signature (16 bytes)
+    // put the remaining part of the createResponse
+    plainTextBuffer.putUInt16(createResponseStructureSize) // StructureSize (2 bytes)
+    plainTextBuffer.putByte((byte) oplockLevel) // OplockLevel (1 byte)
+    plainTextBuffer.putByte((byte) 0) // Flags (1 byte)
+    plainTextBuffer.putUInt32(createAction.value) // CreateAction (4 bytes)
+    MsDataTypes.putFileTime(fileTime, plainTextBuffer) // CreationTime (8 bytes)
+    MsDataTypes.putFileTime(fileTime, plainTextBuffer) // LastAccessTime (8 bytes)
+    MsDataTypes.putFileTime(fileTime, plainTextBuffer) // LastWriteTime (8 bytes)
+    MsDataTypes.putFileTime(fileTime, plainTextBuffer) // ChangeTime (8 bytes)
+    plainTextBuffer.putLong(allocationSize) // AllocationSize (8 bytes)
+    plainTextBuffer.putUInt64(endOfFile) // EndOfFile (8 bytes)
+    plainTextBuffer.putUInt32(EnumWithValue.EnumUtils.toLong(fileAttributes)) // FileAttributes (4 bytes)
+    plainTextBuffer.putReserved4() // Reserved2 (4 bytes)
+    fileId.write(plainTextBuffer) // FileId (16 bytes)
+    plainTextBuffer.putUInt32(0L) // CreateContextsOffset (4 bytes)
+    plainTextBuffer.putUInt32(0L) // CreateContextsLength (4 bytes)
+    plainTextBuffer.rpos(0)
+    int plainTextSize = plainTextBuffer.available()
+    byte[] plainText = plainTextBuffer.compactData
+
+    then:
+    plainTextSize == plainText.length
+
+    when:
+    SMB2PacketData plainTextPacketData = smb2PacketFactory.read(plainText)
+    SMB2CreateResponse createResponse = new SMB2CreateResponse()
+    createResponse.read(plainTextPacketData)
+
+    then:
+    createResponse instanceof SMB2CreateResponse
+
+    when:
+    GCMParameterSpec parameterSpec = new GCMParameterSpec(128, nonce)
+    byte[] aad = SMB2TransformHeaderFunctions.newAAD(nonceField, plainTextSize, sessionId)
+    Cipher cipher = Cipher.getInstance(algorithm.algorithmName, javaBCProvider)
+    // Always use the decryptionKey to encrypt it, this is because the message is supposed to be received by client
+    // And the Server's encrypt and decrypt Keys are in reverse order of client Keys
+    cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(smb30xExpectedDecryptionKey, algorithm.algorithmName), parameterSpec)
+    cipher.updateAAD(aad)
+    byte[] cipherTextWithMac = cipher.doFinal(plainText)
+
+    then:
+    cipherTextWithMac.length == plainTextSize + authenticationTagLength
+
+    when:
+    // Actual Writing the Packet with SMB2_TRANSFORM_HEADER
+    SMBBuffer cipherTextBuffer = new SMBBuffer()
+    cipherTextBuffer.putRawBytes(transformHeaderProtocolId) // ProtocolId (4 bytes)
+    cipherTextBuffer.putRawBytes(cipherTextWithMac, plainTextSize, authenticationTagLength) // Signature (16 bytes)
+    cipherTextBuffer.putRawBytes(aad) // Nonce (16 bytes), OriginalMessageSize (4 bytes), Reserved (2 bytes), Flags/EncryptionAlgorithm (2 bytes), SessionId (8 bytes)
+    cipherTextBuffer.putRawBytes(cipherTextWithMac, 0, plainTextSize) // encrypted packet (variable)
+    cipherTextBuffer.rpos(0)
+    SMB2PacketData encryptedPacketData = converter.read(cipherTextBuffer.compactData, new DecryptPacketInfo(new SecretKeySpec(smb30xExpectedDecryptionKey, algorithm.algorithmName), algorithm))
+    SMB2Packet decryptedPacket = smb2MessageConverter.readPacket(null, encryptedPacketData)
+
+    then:
+    decryptedPacket.fromDecrypt
+    decryptedPacket instanceof SMB2CreateResponse
+
+    when:
+    SMB2CreateResponse decryptedCreateResponse = (SMB2CreateResponse) decryptedPacket
+    SMB2Header decryptedHeader = decryptedCreateResponse.getHeader()
+
+    then:
+    decryptedHeader.statusCode == NtStatus.STATUS_SUCCESS.value
+    decryptedHeader.treeId == treeId
+    decryptedHeader.sessionId == sessionId
+    decryptedHeader.messageId == messageId
+    decryptedHeader.flags == headerFlags
+    Arrays.equals(decryptedHeader.signature, new byte[16])
+//    decryptedCreateResponse.endOfFile == endOfFile
+//    decryptedCreateResponse.allocationSize == allocationSize
+//    decryptedCreateResponse.oplockLevel == oplockLevel
+    decryptedCreateResponse.creationTime == fileTime
+    decryptedCreateResponse.lastAccessTime == fileTime
+    decryptedCreateResponse.lastWriteTime == fileTime
+    decryptedCreateResponse.changeTime == fileTime
+    decryptedCreateResponse.fileAttributes == fileAttributes
+  }
+}

--- a/src/test/groovy/com/hierynomus/security/CryptographicKeysGeneratorSpec.groovy
+++ b/src/test/groovy/com/hierynomus/security/CryptographicKeysGeneratorSpec.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.security
+
+import com.hierynomus.protocol.commons.ByteArrayUtils
+import spock.lang.Specification
+
+import javax.crypto.spec.SecretKeySpec
+
+class CryptographicKeysGeneratorSpec extends Specification {
+
+  def sessionKey = ByteArrayUtils.parseHex("09921d4431b171b977370bf8910900f9")
+  def smb30xExpectedSigningKey = ByteArrayUtils.parseHex("8f5a6907bce9ec89b8f89e560d4e2e18")
+  def smb30xExpectedEncryptionKey = ByteArrayUtils.parseHex("858e8cba1f7068969e825b2b538830c4")
+  def smb30xExpectedDecryptionKey = ByteArrayUtils.parseHex("df91d31ef09a01fd4d2a093c42deef46")
+
+  def "should able to generate correct signingKey for Smb30x"() {
+    when:
+    def generatedKey = CryptographicKeysGenerator.generateKey(
+      new SecretKeySpec(sessionKey, ""),
+      CryptographicKeysGenerator.Smb30xSigningLabelByteArray,
+      CryptographicKeysGenerator.Smb30xSigningContextByteArray,
+      "AesCmac"
+    )
+
+    then:
+    Arrays.equals(smb30xExpectedSigningKey, generatedKey.getEncoded())
+  }
+
+  def "should able to generate correct encryptionKey for Smb30x"() {
+    when:
+    def generatedKey = CryptographicKeysGenerator.generateKey(
+      new SecretKeySpec(sessionKey, ""),
+      CryptographicKeysGenerator.Smb30xEncryptLabelByteArray,
+      CryptographicKeysGenerator.Smb30xEncryptContextByteArray,
+      "AES/CCM/NoPadding"
+    )
+
+    then:
+    Arrays.equals(smb30xExpectedEncryptionKey, generatedKey.getEncoded())
+  }
+
+  def "should able to generate correct decryptionKey for Smb30x"() {
+    when:
+    def generatedKey = CryptographicKeysGenerator.generateKey(
+      new SecretKeySpec(sessionKey, ""),
+      CryptographicKeysGenerator.Smb30xDecryptLabelByteArray,
+      CryptographicKeysGenerator.Smb30xDecryptContextByteArray,
+      "AES/CCM/NoPadding"
+    )
+
+    then:
+    Arrays.equals(smb30xExpectedDecryptionKey, generatedKey.getEncoded())
+  }
+}

--- a/src/test/groovy/com/hierynomus/smbj/session/PacketEncryptorSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/session/PacketEncryptorSpec.groovy
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.smbj.session
+
+import com.hierynomus.msdtyp.AccessMask
+import com.hierynomus.msfscc.FileAttributes
+import com.hierynomus.mssmb2.SMB2CreateDisposition
+import com.hierynomus.mssmb2.SMB2CreateOptions
+import com.hierynomus.mssmb2.SMB2Dialect
+import com.hierynomus.mssmb2.SMB2MessageFlag
+import com.hierynomus.mssmb2.SMB2ShareAccess
+import com.hierynomus.mssmb2.SMB2TransformHeaderFunctions
+import com.hierynomus.mssmb2.Smb2EncryptionCipher
+import com.hierynomus.mssmb2.messages.SMB2CreateRequest
+import com.hierynomus.protocol.commons.ByteArrayUtils
+import com.hierynomus.protocol.commons.Charsets
+import com.hierynomus.protocol.commons.EnumWithValue
+import com.hierynomus.security.bc.BCSecurityProvider
+import com.hierynomus.smb.SMBBuffer
+import com.hierynomus.smbj.common.Check
+import com.hierynomus.smbj.common.SmbPath
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import spock.lang.Specification
+
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class PacketEncryptorSpec extends Specification {
+
+  // groovy version of java's new byte[]{(byte) 0xFE, 'S', 'M', 'B'}
+  byte[] smb2HeaderProtocolId = [(byte) 0xFE, (byte) 0x53, (byte) 0x4D, (byte) 0x42] as byte[]
+  // groovy version of java's new byte[]{(byte) 0xFD, 'S', 'M', 'B'}
+  byte[] transformHeaderProtocolId = [(byte) 0xFD, (byte) 0x53, (byte) 0x4D, (byte) 0x42] as byte[]
+
+  def sessionKey = ByteArrayUtils.parseHex("09921d4431b171b977370bf8910900f9")
+  def smb30xExpectedSigningKey = ByteArrayUtils.parseHex("8f5a6907bce9ec89b8f89e560d4e2e18")
+  def smb30xExpectedEncryptionKey = ByteArrayUtils.parseHex("858e8cba1f7068969e825b2b538830c4")
+  def smb30xExpectedDecryptionKey = ByteArrayUtils.parseHex("df91d31ef09a01fd4d2a093c42deef46")
+  def javaBCProvider = new BouncyCastleProvider()
+  def smbjBCProvider = new BCSecurityProvider()
+
+  def "should able to encrypt a message correctly for AES-CCM"() {
+    given:
+    SMB2Dialect dialect = SMB2Dialect.SMB_3_0
+    Smb2EncryptionCipher algorithm = Smb2EncryptionCipher.AES_128_CCM
+    String path = "test.txt"
+    SMB2CreateRequest message = new SMB2CreateRequest(
+      dialect,
+      1, 1,
+      null,
+      EnumSet.of(AccessMask.GENERIC_ALL),
+      EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
+      SMB2ShareAccess.ALL,
+      SMB2CreateDisposition.FILE_OPEN,
+      null,
+      new SmbPath("127.0.0.1", "share01", path)
+    )
+    PacketEncryptor packetEncryptor = new PacketEncryptor(
+      dialect,
+      new BCSecurityProvider(),
+      algorithm
+    )
+    packetEncryptor.init(sessionKey)
+
+    when:
+    def encryptedMessage = packetEncryptor.encrypt(message)
+
+    then:
+    encryptedMessage instanceof PacketEncryptor.EncryptedPacketWrapper
+
+    when:
+    SMBBuffer buffer = new SMBBuffer()
+    encryptedMessage.write(buffer)
+    // read the SMB2_TRANSFORM_HEADER
+    buffer.rpos(0)
+    byte[] protocolId = buffer.readRawBytes(4)
+    byte[] signature = buffer.readRawBytes(16) // Signature (16 bytes)
+    byte[] nonceField = buffer.readRawBytes(16) // Nonce (16 bytes)
+    long originalMessageSize = buffer.readUInt32() // OriginalMessageSize (4 bytes)
+    buffer.skip(2) // Reserved (2 bytes)
+    int flagsOrEncryptionAlgorithm = buffer.readUInt16() // Flags/EncryptionAlgorithm (2 bytes)
+    long sessionId = buffer.readLong() // SessionId (8 bytes)
+    byte[] cipherText = buffer.readRawBytes((int) originalMessageSize) // encrypted packet (variable)
+
+    then:
+    // Check we see a valid header start
+    Check.ensureEquals(protocolId, transformHeaderProtocolId, "Could not find SMB2_TRANSFORM_HEADER")
+    // read the remaining part of the SMB2_TRANSFORM_HEADER
+    flagsOrEncryptionAlgorithm == 1
+    sessionId == 1
+
+    when:
+    byte[] aad = SMB2TransformHeaderFunctions.newAAD(nonceField, (int) originalMessageSize, sessionId)
+    byte[] nonce = SMB2TransformHeaderFunctions.getActualNonce(algorithm, nonceField)
+    GCMParameterSpec parameterSpec = new GCMParameterSpec(128, nonce)
+    Cipher cipher = Cipher.getInstance(algorithm.getAlgorithmName(), javaBCProvider)
+    // Always use the encryptionKey to decrypt it, this is because the message is supposed to be received by Server
+    // And the Server's encrypt and decrypt Keys are in reverse order of client Keys
+    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(smb30xExpectedEncryptionKey, algorithm.getAlgorithmName()), parameterSpec)
+    cipher.updateAAD(aad)
+    cipher.update(cipherText)
+    byte[] plainText = cipher.doFinal(signature)
+    SMBBuffer decryptedBuffer = new SMBBuffer()
+    decryptedBuffer.putRawBytes(plainText)
+    decryptedBuffer.rpos(0)
+    // Read the plainText message
+    byte[] smb2ProtocolId =  decryptedBuffer.readRawBytes(4) // ProtocolId (4 bytes)
+    int headerStructureSize = decryptedBuffer.readUInt16() // StructureSize (2 bytes)
+    int creditCharge = decryptedBuffer.readUInt16() // CreditCharge (2 bytes)
+    long statusCode = decryptedBuffer.readUInt32() // Status (4 bytes)
+    int command = decryptedBuffer.readUInt16() // Command (2 bytes)
+    int creditRequest = decryptedBuffer.readUInt16() // CreditRequest/CreditResponse (2 bytes)
+    long flags = decryptedBuffer.readUInt32() // Flags (4 bytes)
+    long nextCommandOffset = decryptedBuffer.readUInt32() // NextCommand (4 bytes)
+    long messageId = decryptedBuffer.readLong() // MessageId (4 bytes)
+    decryptedBuffer.skip(4) // Reserved (4 bytes)
+    long treeId = decryptedBuffer.readUInt32() // TreeId (4 bytes)
+    long plainTextSessionId = decryptedBuffer.readLong() // SessionId (8 bytes)
+    byte[] readSignature = decryptedBuffer.readRawBytes(16) // Signature (16 bytes)
+
+    then:
+    // Check we see a correct and valid header start
+    Check.ensureEquals(smb2ProtocolId, smb2HeaderProtocolId, "Could not find SMB2 Packet header")
+    headerStructureSize == 64 // StructureSize (2 bytes)
+    command == 0x0005 // Command (2 bytes)
+    (flags & SMB2MessageFlag.SMB2_FLAGS_SIGNED.value) == 0
+    treeId == 1 // TreeId (4 bytes)
+    plainTextSessionId == 1 // SessionId (8 bytes)
+    Arrays.equals(readSignature, new byte[16])
+
+    when:
+    int messageStructureSize = decryptedBuffer.readUInt16() // StructureSize (2 bytes)
+    byte securityFlags = decryptedBuffer.readByte() // SecurityFlags (1 byte) - Reserved
+    byte oplockLevel = decryptedBuffer.readByte() // RequestedOpLockLevel (1 byte)
+    long impersonationLevel = decryptedBuffer.readUInt32() // ImpersonationLevel (4 bytes) - Identification
+    long smbCreateFlags = decryptedBuffer.readLong() // SmbCreateFlags (8 bytes)
+    decryptedBuffer.skip(8) // Reserved (8 bytes)
+    Set<AccessMask> desiredAccess = EnumWithValue.EnumUtils.toEnumSet(decryptedBuffer.readUInt32(), AccessMask.class) // DesiredAccess (4 bytes)
+    Set<FileAttributes> fileAttributes = EnumWithValue.EnumUtils.toEnumSet(decryptedBuffer.readUInt32(), FileAttributes.class) // FileAttributes (4 bytes)
+    Set<SMB2ShareAccess> shareAccess = EnumWithValue.EnumUtils.toEnumSet(decryptedBuffer.readUInt32(), SMB2ShareAccess.class) // ShareAccess (4 bytes)
+    SMB2CreateDisposition createDisposition = EnumWithValue.EnumUtils.valueOf(decryptedBuffer.readUInt32(), SMB2CreateDisposition.class, null) // CreateDisposition (4 bytes)
+    Set<SMB2CreateOptions> createOptions = EnumWithValue.EnumUtils.toEnumSet(decryptedBuffer.readUInt32(), SMB2CreateOptions.class) // CreateOptions (4 bytes)
+    int nameOffset = decryptedBuffer.readUInt16() // NameOffset (2 bytes)
+    int nameLength = decryptedBuffer.readUInt16() // NameLength (2 bytes)
+    long createContextsOffset = decryptedBuffer.readUInt32() // CreateContextsOffset (4 bytes)
+    long createContextsLength = decryptedBuffer.readUInt32() // CreateContextsLength (4 bytes)
+    int createRequestBufferStartPos = decryptedBuffer.rpos()
+    decryptedBuffer.rpos(nameOffset)
+    byte[] nameBytes = decryptedBuffer.readRawBytes(nameLength)
+    String name = new String(nameBytes, Charsets.UTF_16LE)
+
+    then:
+    messageStructureSize == 57
+    securityFlags == (byte) 0
+    oplockLevel == (byte) 0
+    impersonationLevel == 1
+    smbCreateFlags == 0
+    desiredAccess == EnumSet.of(AccessMask.GENERIC_ALL)
+    fileAttributes == EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL)
+    shareAccess == SMB2ShareAccess.ALL
+    createDisposition == SMB2CreateDisposition.FILE_OPEN
+    createOptions.isEmpty()
+    nameOffset == (headerStructureSize + messageStructureSize - 1)
+    nameLength == (path.length() * 2) // time 2 because unicode
+    createContextsOffset == 0L
+    createContextsLength == 0L
+    createRequestBufferStartPos == nameOffset
+    name == path
+  }
+}


### PR DESCRIPTION
Implement SMB3 Signing (AesCmac), 3.0.x encryption (AES/CCM) and 3.1.1 encryption (AES/GCM)

Fix Cancel Request didn't send sessionId. Added NegotitateConext classes for 3.1.1 and applied them on negotiate request and response. Added transformHeader for SMB3 encryption and its packet factory for decrypt. Added PacketEncryptor for packet encryption. Added AEADBlockCipher for AES/CCM/NoPadding and AES/GCM/NoPadding, and this may integrate with the old cipher interface in the future. Handle the session and treeConnect flags on response for requiring encryption, so that, the library is able using plainText to access other share but only required encrypt share will be encrypted. Added AesCmac support in PacketSignatory for SMB3 signing. CryptographicKeysGenerator is added for key generate but not yet passed the security provider to it and always using BC classes directly. DigestUtil is added for 3.1.1 preAuthHashValue and the session authenticate process had always changed in order to calculate the preAuthHashValue for 3.1.1.

Hi @hierynomus,
I think this pull request should not directly merge to master right now. It should merge to a feature branch so that more testing and improvement could be done. However, it doesn't seems github provide me any option for doing this. What do you think about it?

Demo config for using dialect 3.0.2
```
SmbConfig config = SmbConfig.builder()
            .withDialects(SMB2Dialect.SMB_3_0_2)
            .withSecurityProvider(BCSecurityProvider())
            .withCapabilities(SMB2GlobalCapability.SMB2_GLOBAL_CAP_DFS, SMB2GlobalCapability.SMB2_GLOBAL_CAP_ENCRYPTION)
            .withEncryptData(true)
            .build()
```

Demo config for using dialect 3.1.1, adding BouncyCastleProvider is recommended on 3.1.1 as JceSecurityProvider had optimization for GCM.
```
Provider[] providerList = java.security.Security.getProviders();
BouncyCastleProvider bcSecurityProvider = new BouncyCastleProvider();
java.security.Security.insertProviderAt(bcSecurityProvider, providerList.length);

SmbConfig config = SmbConfig.builder()
            .withDialects(SMB2Dialect.SMB_3_1_1)
            .withCapabilities(SMB2GlobalCapability.SMB2_GLOBAL_CAP_DFS, SMB2GlobalCapability.SMB2_GLOBAL_CAP_ENCRYPTION)
            .withEncryptData(true)
            .build()
```

Related to #151 and it should able to solve the issue. Related to #287.