### PR TITLE
Fix the invalid checking for UInt64 (causing it only supports 63 bits)

### DIFF
--- a/src/main/java/com/hierynomus/protocol/commons/buffer/Endian.java
+++ b/src/main/java/com/hierynomus/protocol/commons/buffer/Endian.java
@@ -108,19 +108,12 @@ public abstract class Endian {
 
         @Override
         public <T extends Buffer<T>> void writeUInt64(Buffer<T> buffer, long uint64) {
-            if (uint64 < 0) {
-                throw new IllegalArgumentException("Invalid uint64 value: " + uint64);
-            }
             writeLong(buffer, uint64);
         }
 
         @Override
         public <T extends Buffer<T>> long readUInt64(Buffer<T> buffer) throws Buffer.BufferException {
-            long uint64 = (readUInt32(buffer) << 32) + (readUInt32(buffer) & 0xFFFFFFFFL);
-            if (uint64 < 0) {
-                throw new Buffer.BufferException("Cannot handle values > " + Long.MAX_VALUE);
-            }
-            return uint64;
+            return readLong(buffer);
         }
 
         @Override
@@ -232,19 +225,12 @@ public abstract class Endian {
 
         @Override
         public <T extends Buffer<T>> void writeUInt64(Buffer<T> buffer, long uint64) {
-            if (uint64 < 0) {
-                throw new IllegalArgumentException("Invalid uint64 value: " + uint64);
-            }
             writeLong(buffer, uint64);
         }
 
         @Override
         public <T extends Buffer<T>> long readUInt64(Buffer<T> buffer) throws Buffer.BufferException {
-            long uint64 = (readUInt32(buffer) & 0xFFFFFFFFL) + (readUInt32(buffer) << 32);
-            if (uint64 < 0) {
-                throw new Buffer.BufferException("Cannot handle values > " + Long.MAX_VALUE);
-            }
-            return uint64;
+            return readLong(buffer);
         }
 
         @Override


### PR DESCRIPTION
Checking is negative or not for 8 bytes variable (long) is meaningless when putting to another unsigned 8 bytes variable. And this causing only supports up to 63 bits instead of 64 bits (8 bytes).

The write request is not able to write to offset > 63 bits without this fix.

@hierynomus, based on my understanding on JAVA 8 unsigned operations added to `Long` (https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html), it will keep using the normal long primitive type (which is signed) and using those unsigned operations to deal with the unsigned variable. So, I think we should read/write the UInt64 as same as long and only consider they are unsigned when using them.