### PR TITLE
Track usage count for Connection and only close it if it not used anymore

### DIFF
--- a/src/main/java/com/hierynomus/smbj/SMBClient.java
+++ b/src/main/java/com/hierynomus/smbj/SMBClient.java
@@ -97,6 +97,12 @@ public class SMBClient implements Closeable {
         synchronized (this) {
             String hostPort = hostname + ":" + port;
             Connection cachedConnection = connectionTable.get(hostPort);
+            if (cachedConnection != null) {
+                cachedConnection = cachedConnection.share();
+                if(cachedConnection != null && cachedConnection.isConnected()) {
+                    return cachedConnection;
+                }
+            }
             if (cachedConnection == null || !cachedConnection.isConnected()) {
                 Connection connection = new Connection(config, this, bus);
                 try {
@@ -107,8 +113,9 @@ public class SMBClient implements Closeable {
                 }
                 connectionTable.put(hostPort, connection);
                 return connection;
+            } else {
+                return cachedConnection;
             }
-            return connectionTable.get(hostPort);
         }
     }
 

--- a/src/test/groovy/com/hierynomus/smbj/SMBClientSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/SMBClientSpec.groovy
@@ -69,4 +69,16 @@ class SMBClientSpec extends Specification {
     then:
     con1 != con2
   }
+
+  def "should not disconnect if more than one connection to the same host is open"() {
+    given:
+    def con1 = client.connect("hostA")
+    def con2 = client.connect("hostA")
+
+    when:
+    con1.close()
+
+    then:
+    con2.isConnected()
+  }
 }


### PR DESCRIPTION
SMBClient#connect returns a shared connection. If one of the users closes
the connection, all callers are disconnected. This code should work:

```java
public class TestOpen {
    public static void main(String[] argv) throws Exception {
        String username = "";
        char[] password = "".toCharArray();
        String host = "";
        String share = "";

        try(SMBClient client = new SMBClient(SmbConfig.builder().withDfsEnabled(false).build())) {
            Connection con1 = client.connect(host);
            Connection con2 = client.connect(host);

            Session session1 = con1.authenticate(new AuthenticationContext(username, password, null));
            Session session2 = con2.authenticate(new AuthenticationContext(username, password, null));

            DiskShare share1 = (DiskShare) session1.connectShare(share);
            for(FileIdBothDirectoryInformation fidbdi: share1.list("")) {
                System.out.println(fidbdi.getFileName());
            }
            share1.close();
            session1.close();
            con1.close();

            DiskShare share2 = (DiskShare) session2.connectShare(share);
            for(FileIdBothDirectoryInformation fidbdi: share2.list("")) {
                System.out.println(fidbdi.getFileName());
            }
            share2.close();
            session2.close();
            con2.close();
        }
    }
}
```

But fails before this commit, because session2 is identical to session1
and the session1.close() directly terminates the underlying connection.

With this change session1 and session2 are still the same objects, but
they hold an internal usage count. Each call call SMBClient#connect
increments the usage counter and each call to Connection#close decrements
it. Only if the usage counter drops to zero, the connection is really
closed.

This implements suggestion (3) from #511.