### PR TITLE
add getter to secretKey on PacketSignatory.java

### DIFF
--- a/src/main/java/com/hierynomus/smbj/session/PacketSignatory.java
+++ b/src/main/java/com/hierynomus/smbj/session/PacketSignatory.java
@@ -39,6 +39,7 @@ public class PacketSignatory {
     private SecurityProvider securityProvider;
     private String algorithm;
     private byte[] secretKey;
+    public byte[] getSecretKey() { return secretKey; } 
 
     PacketSignatory(SMB2Dialect dialect, SecurityProvider securityProvider) {
         this.dialect = dialect;


### PR DESCRIPTION
provide a getter for secretKey that can be used by upper protocol levels. 
(The Microsoft SAM Remote Protocol needs this key to encrypt hashes to set an account password)