### PR TITLE
address issue #604 - stop closing the dfs share connection immediately.

### DIFF
--- a/src/main/java/com/hierynomus/smbj/paths/DFSPathResolver.java
+++ b/src/main/java/com/hierynomus/smbj/paths/DFSPathResolver.java
@@ -421,7 +421,8 @@ public class DFSPathResolver implements PathResolver {
             dfsSession = connection.authenticate(auth);
         }
 
-        try (Share dfsShare = dfsSession.connectShare("IPC$")) {
+        try {
+            Share dfsShare = dfsSession.connectShare("IPC$");
             return getReferral(type, dfsShare, path);
         } catch (Buffer.BufferException | IOException e) {
             throw new DFSException(e);

--- a/src/main/java/com/hierynomus/smbj/paths/DFSPathResolver.java
+++ b/src/main/java/com/hierynomus/smbj/paths/DFSPathResolver.java
@@ -422,7 +422,7 @@ public class DFSPathResolver implements PathResolver {
         }
 
         try {
-            Share dfsShare = dfsSession.connectShare("IPC$");
+            Share dfsShare = dfsSession.connectShare("IPC$"); // explicitly not closed as we want to re-use the cached Share for multiple requests
             return getReferral(type, dfsShare, path);
         } catch (Buffer.BufferException | IOException e) {
             throw new DFSException(e);


### PR DESCRIPTION
Stop closing the `IPC$` share every time you connect to it to get a referral. 

In my use case where I am crawling a smb2 share, this resulted in 1000's of connections to `IPC$` every hour. 

Let these connections get cleaned up from the `logoff` method.

I tested this against a fairly massive distributed share and experienced no connection bloat.

perhaps it would be safer to keep these in a dfs share cache that expires if not used after `n` time and has a max cap of say 100 of these connections... but in my fairly massive use case it does not matter. 