### PR TITLE
address issue #603

### DIFF
--- a/src/it/groovy/com/hierynomus/smbj/DfsIntegrationSpec.groovy
+++ b/src/it/groovy/com/hierynomus/smbj/DfsIntegrationSpec.groovy
@@ -92,4 +92,21 @@ class DfsIntegrationSpec extends Specification {
     cleanup:
     share.close()
   }
+
+  def "should have filename for regular directory share when dfs is enabled GH#603"() {
+    given:
+    def userShare = session.connectShare("user")
+    userShare.mkdir("a_directory")
+
+    when:
+    def dir = (userShare as DiskShare).openDirectory("a_directory", EnumSet.of(AccessMask.GENERIC_READ), null, EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ), SMB2CreateDisposition.FILE_OPEN, null)
+
+    then:
+    dir.getFileName() == "a_directory"
+
+    cleanup:
+    dir.close()
+    userShare.rmdir("a_directory", false)
+    userShare.close()
+  }
 }

--- a/src/it/groovy/com/hierynomus/smbj/DfsIntegrationSpec.groovy
+++ b/src/it/groovy/com/hierynomus/smbj/DfsIntegrationSpec.groovy
@@ -102,11 +102,14 @@ class DfsIntegrationSpec extends Specification {
     def dir = (userShare as DiskShare).openDirectory("a_directory", EnumSet.of(AccessMask.GENERIC_READ), null, EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ), SMB2CreateDisposition.FILE_OPEN, null)
 
     then:
-    dir.getFileName() == "a_directory"
+    dir.getPath() == "a_directory"
+    dir.getFileName() == "\\\\127.0.0.1\\user\\a_directory"
+    dir.getUncPath() == "\\\\127.0.0.1\\user\\a_directory"
 
     cleanup:
     dir.close()
     userShare.rmdir("a_directory", false)
     userShare.close()
   }
+
 }

--- a/src/it/groovy/com/hierynomus/smbj/SMB2DirectoryIntegrationTest.groovy
+++ b/src/it/groovy/com/hierynomus/smbj/SMB2DirectoryIntegrationTest.groovy
@@ -157,5 +157,4 @@ class SMB2DirectoryIntegrationTest extends Specification {
     cleanup:
     share.rmdir("directory", true)
   }
-
 }

--- a/src/main/java/com/hierynomus/smbj/share/DiskEntry.java
+++ b/src/main/java/com/hierynomus/smbj/share/DiskEntry.java
@@ -43,10 +43,28 @@ public abstract class DiskEntry extends Open<DiskShare> {
         share.closeFileIdNoWait(fileId);
     }
 
+    /**
+     * Gets the UNC path of this disk entry.
+     * @deprecated as of 0.11.0 use {@link DiskEntry#getUncPath()} instead.
+     * @return The UNC path of this disk entry.
+     */
+    @Deprecated
     public String getFileName() {
         return name.toUncPath();
     }
-    
+
+    /**
+     * Gets the UNC path of this disk entry.
+     * @return The UNC path of this disk entry. Example: \\192.168.1.51\share\folder0\test1.txt
+     */
+    public String getUncPath() {
+        return name.toUncPath();
+    }
+
+    /**
+     * Gets the relative path of this disk entry.
+     * @return The relative path of this disk entry. Example: folder0/test1.txt
+     */
     public String getPath() {
         return name.getPath();
     }

--- a/src/main/java/com/hierynomus/smbj/share/DiskEntry.java
+++ b/src/main/java/com/hierynomus/smbj/share/DiskEntry.java
@@ -44,6 +44,10 @@ public abstract class DiskEntry extends Open<DiskShare> {
     }
 
     public String getFileName() {
+        return name.toUncPath();
+    }
+    
+    public String getPath() {
         return name.getPath();
     }
 


### PR DESCRIPTION
* address #603 where getFileName was returning path instead of unc path.
* deprecate getFileName - it's confusing. Instead offer a getPath and getUncPath method to DiskEntry.