### PR TITLE
Reducing logging for smb3

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/packet/SMB3DecryptingPacketHandler.java
+++ b/src/main/java/com/hierynomus/smbj/connection/packet/SMB3DecryptingPacketHandler.java
@@ -100,7 +100,7 @@ public class SMB3DecryptingPacketHandler extends AbstractIncomingPacketHandler {
     @Override
     protected void doHandle(SMBPacketData<?> packetData) throws TransportException {
         SMB3EncryptedPacketData data = (SMB3EncryptedPacketData) packetData;
-        logger.info("Decrypting packet {}", data);
+        logger.debug("Decrypting packet {}", data);
 
         if (!encryptor.canDecrypt(data)) {
             next.handle(new DeadLetterPacketData(packetData.getHeader()));


### PR DESCRIPTION
For each smb3 packet there's an info log message which produces a tremendous amount of output.
I would suggest to reduce log level to debug (or trace; similarly as in one of the other packet reciever classes).