### PR TITLE
Read fileId of FileIdBothDirectoryInformation and FileIdFullDirectoryInformation as long

### DIFF
--- a/src/it/groovy/com/hierynomus/smbj/IntegrationTest.groovy
+++ b/src/it/groovy/com/hierynomus/smbj/IntegrationTest.groovy
@@ -16,6 +16,8 @@
 package com.hierynomus.smbj
 
 import com.hierynomus.msdtyp.AccessMask
+import com.hierynomus.msfscc.fileinformation.FileIdFullDirectoryInformation
+import com.hierynomus.msfscc.fileinformation.FileInternalInformation
 import com.hierynomus.mssmb2.SMB2Dialect
 import com.hierynomus.mssmb2.SMB2ShareAccess
 import com.hierynomus.security.bc.BCSecurityProvider
@@ -122,4 +124,32 @@ class IntegrationTest extends Specification {
     then:
     noExceptionThrown()
   }
+
+  def "should be able to read fileID from FileIdBothDirectoryInformation"() {
+    when:
+    def session = connection.authenticate(AUTH)
+    def share = session.connectShare(SHARE) as DiskShare
+    def children = share.list(FOLDER_THAT_EXISTS)
+    def firstChild = children.get(1);
+    def firstChildFile = share.open(FOLDER_THAT_EXISTS + '\\' + firstChild.getFileName(), EnumSet.of(AccessMask.GENERIC_READ), null, SMB2ShareAccess.ALL, FILE_OPEN, null)
+    def fileInternalInformation = firstChildFile.getFileInformation(FileInternalInformation.class)
+
+    then:
+    firstChild.fileId == fileInternalInformation.indexNumber // both refer to the same file ID
+  }
+
+  def "should be able to read fileID from FileIdFullDirectoryInformation"() {
+    when:
+    def session = connection.authenticate(AUTH)
+    def share = session.connectShare(SHARE) as DiskShare
+    def children = share.list(FOLDER_THAT_EXISTS, FileIdFullDirectoryInformation.class)
+    def firstChild = children.get(1);
+    def firstChildFile = share.open(FOLDER_THAT_EXISTS + '\\' + firstChild.getFileName(), EnumSet.of(AccessMask.GENERIC_READ), null, SMB2ShareAccess.ALL, FILE_OPEN, null)
+    def fileInternalInformation = firstChildFile.getFileInformation(FileInternalInformation.class)
+
+    then:
+    firstChild.fileId == fileInternalInformation.indexNumber // both refer to the same file ID
+  }
+
+
 }

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileIdBothDirectoryInformation.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileIdBothDirectoryInformation.java
@@ -28,10 +28,10 @@ public class FileIdBothDirectoryInformation extends FileDirectoryQueryableInform
     private final long fileAttributes;
     private final long eaSize;
     private final String shortName;
-    private final byte[] fileId; // This is not the SMB2FileId, but not sure what one can do with this id.
+    private final long fileId; // A 64-bit value that uniquely identifies a file within a given volume.
 
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    FileIdBothDirectoryInformation(long nextOffset, long fileIndex, String fileName, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, FileTime changeTime, long endOfFile, long allocationSize, long fileAttributes, long eaSize, String shortName, byte[] fileId) {
+    FileIdBothDirectoryInformation(long nextOffset, long fileIndex, String fileName, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, FileTime changeTime, long endOfFile, long allocationSize, long fileAttributes, long eaSize, String shortName, long fileId) {
         super(nextOffset, fileIndex, fileName);
         this.creationTime = creationTime;
         this.lastAccessTime = lastAccessTime;
@@ -81,7 +81,7 @@ public class FileIdBothDirectoryInformation extends FileDirectoryQueryableInform
         return shortName;
     }
 
-    public byte[] getFileId() {
+    public long getFileId() {
         return fileId;
     }
 }

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileIdFullDirectoryInformation.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileIdFullDirectoryInformation.java
@@ -27,10 +27,10 @@ public class FileIdFullDirectoryInformation extends FileDirectoryQueryableInform
     private final long allocationSize;
     private final long fileAttributes;
     private final long eaSize;
-    private final byte[] fileId; // This is not the SMB2FileId, but not sure what one can do with this id.
+    private final long fileId; // A 64-bit value that uniquely identifies a file within a given volume.
 
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    FileIdFullDirectoryInformation(long nextOffset, long fileIndex, String fileName, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, FileTime changeTime, long endOfFile, long allocationSize, long fileAttributes, long eaSize, byte[] fileId) {
+    FileIdFullDirectoryInformation(long nextOffset, long fileIndex, String fileName, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, FileTime changeTime, long endOfFile, long allocationSize, long fileAttributes, long eaSize, long fileId) {
         super(nextOffset, fileIndex, fileName);
         this.creationTime = creationTime;
         this.lastAccessTime = lastAccessTime;
@@ -75,7 +75,7 @@ public class FileIdFullDirectoryInformation extends FileDirectoryQueryableInform
         return eaSize;
     }
 
-    public byte[] getFileId() {
+    public long getFileId() {
         return fileId;
     }
 }

--- a/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
+++ b/src/main/java/com/hierynomus/msfscc/fileinformation/FileInformationFactory.java
@@ -637,7 +637,7 @@ public class FileInformationFactory {
         byte[] shortNameBytes = buffer.readRawBytes(24); // Shortname
         String shortName = new String(shortNameBytes, 0, shortNameLen, Charsets.UTF_16LE);
         buffer.readUInt16(); // Reserved2
-        byte[] fileId = buffer.readRawBytes(8);
+        long fileId = buffer.readLong();
         String fileName = buffer.readString(Charsets.UTF_16LE, (int) fileNameLen / 2);
         FileIdBothDirectoryInformation fi = new FileIdBothDirectoryInformation(
             nextOffset, fileIndex, fileName,
@@ -667,7 +667,7 @@ public class FileInformationFactory {
         long fileNameLen = buffer.readUInt32();
         long eaSize = buffer.readUInt32();
         buffer.skip(4); // Reserved
-        byte[] fileId = buffer.readRawBytes(8);
+        long fileId = buffer.readLong();
         String fileName = buffer.readString(Charsets.UTF_16LE, (int) fileNameLen / 2);
         FileIdFullDirectoryInformation fi = new FileIdFullDirectoryInformation(
             nextOffset, fileIndex, fileName,


### PR DESCRIPTION
This PR attempts to unify the reading/parsing of the `fileId` field in` FileIdBothDirectoryInformation` and `FileIdFullDirectoryInformation`.

The `fileId` field in `FileIdBothDirectoryInformation` and `FileIdFullDirectoryInformation` and the `indexNumber` in `FileInternalInformation` all refer to the same file ID, described in [MS-FCC].

Currently, the `indexNumber` field in `FileInternalInformation` is of type `long`, but the `fileId` of the other two classes is of type `byte[]`.
I think it would be cleaner if the `fileId` fields of `FileIdBothDirectoryInformation` and `FileIdFullDirectoryInformation` are also exposed as type `long` in the API of this library, as these fields always have 8 bytes.

Specification:
[MS-FCC] section 2.1.9 64-bit file ID
[MS-FCC] section 2.4.17 FileIdBothDirectoryInformation FileId
[MS-FCC] section 2.4.19 FileIdFullDirectoryInformation FileId
[MS-FCC] section 2.4.22 FileInternalInformation IndexNumber

## Changes
* Read fileId of FileIdBothDirectoryInformation into a long
* Read fileId of FileIdFullDirectoryInformation into a long
* Add integration tests to ensure that the fileIds match the fileIndex provided by FileInternalInformation