### PR TITLE
https://github.com/hierynomus/smbj/issues/677

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/Connection.java
+++ b/src/main/java/com/hierynomus/smbj/connection/Connection.java
@@ -168,10 +168,10 @@ public class Connection extends Pooled<Connection> implements Closeable, PacketR
      * @throws IOException If any error occurred during close-ing.
      */
     public void close(boolean force) throws IOException {
-        if (!force && !release()) {
-            return;
-        }
         try {
+            if (!force && !release()) {
+                return;
+            }
             if (!force) {
                 for (Session session : sessionTable.activeSessions()) {
                     try {


### PR DESCRIPTION
https://github.com/hierynomus/smbj/issues/677

this is a fix for above issue. We have faced the same with  our application. In case user making use of 

`try(SmbClient client: newClient()){  ... do usual work with connection and DFS share ...   }`

in our application we are not closing Connection ourselves but we were relying on SmbClient.close() method. Unexpectedly it didnt release all connection and PacketReader threads due the "leases" if the connection was reused several times it has decrement only once. At the end when we read the JavaDoc we found our that TransportLayer.disconnect should be called anytime.
`/* 
     * Close the Connection. If {@code force} is set to true, it forgoes the
     * {@link Session#close()} operation on the open sessions, and it just calls the
     * {@link TransportLayer#disconnect()}.`

Previous implementation was wrong as it returned without calling the transpartLayer.disconnect method