### PR TITLE
Fix: unable to login macOS SMB shares

### DIFF
--- a/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
+++ b/src/main/java/com/hierynomus/smbj/auth/NtlmAuthenticator.java
@@ -124,8 +124,8 @@ public class NtlmAuthenticator implements Authenticator {
                 // If NTLM v2 is used, KeyExchangeKey MUST be set to the given 128-bit SessionBaseKey value.
 
                 // MIC (16 bytes) provided if in AvPairType is key MsvAvFlags with value & 0x00000002 is true
-                Object msAvTimestamp = serverNtlmChallenge.getTargetInfo().getAvPairObject(AvId.MsvAvTimestamp);
-                if (msAvTimestamp != null) {
+                Object msvAvFlags = serverNtlmChallenge.getTargetInfo().getAvPairObject(AvId.MsvAvFlags);
+                if (msvAvFlags instanceof Long && ((long) msvAvFlags & 0x00000002) > 0) {
                     // MIC should be calculated
                     NtlmAuthenticate resp = new NtlmAuthenticate(new byte[0], ntlmv2Response,
                         context.getUsername(), context.getDomain(), workStationName, sessionkey, EnumWithValue.EnumUtils.toLong(negotiateFlags),


### PR DESCRIPTION
This is to fix issue #730 (Cannot connect to SMB shares on macOS machines)

Users who can't wait for the merge can use this jitpack.io build:

```
implementation 'com.github.tdtran:smbj:82b605041f0f81d6f38ec4ab659aa470a5698fa8'
```

I had to add another commit to tell jitpack to build this library with Java 11. It can't be built with the default Java 8.