### PR TITLE
Add missing getter method for applicationKey in SessionContext

### DIFF
--- a/src/main/java/com/hierynomus/smbj/session/SessionContext.java
+++ b/src/main/java/com/hierynomus/smbj/session/SessionContext.java
@@ -96,6 +96,10 @@ public class SessionContext {
         return encryptionKey;
     }
 
+    public SecretKey getApplicationKey() {
+        return applicationKey;
+    }
+
     public void setEncryptionKey(SecretKey encryptionKey) {
         this.encryptionKey = encryptionKey;
     }


### PR DESCRIPTION
In SMB3 context the session key derived application key is used instead of the session key directly (c.f. [MS-SMB2 3.2.4.25](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/901ae284-31d3-4ea1-ae8a-766fc8bfe00e)). This patch adds a getter to the applicationKey field in SessionContext to access that key.