### PR TITLE
Unregister cached server for same hostname

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/SMBProtocolNegotiator.java
+++ b/src/main/java/com/hierynomus/smbj/connection/SMBProtocolNegotiator.java
@@ -229,7 +229,9 @@ class SMBProtocolNegotiator {
         } else if (temp.validate(cachedServer)) {
             negotiationContext.server = cachedServer;
         } else {
-            throw new TransportException(String.format("Different server found for same hostname '%s', disconnecting...", temp.getServerName()));
+            connection.serverList.unregister(temp.getServerName());
+            connection.serverList.registerServer(temp);
+            negotiationContext.server = temp;
         }
     }
 


### PR DESCRIPTION
Hi @hierynomus !

Our infrastructure team sometimes switches the machines behind the same hostnames. In this case, smbj throws an exception, because it keeps the servers in an in-memory list were they stay until an application restart. That forces us to restart the application.

I made a change so that no exception will be thrown but instead the cached server will be unregistered and newly registered if it changed on the same hostname. It would save us much restarting effort, if you could merge this patch. Thanks in advance!!!

Best wishes

Daniel