### PR TITLE
Use a buffered inputstream to read from the socket

### DIFF
--- a/src/main/java/com/hierynomus/smbj/transport/PacketReader.java
+++ b/src/main/java/com/hierynomus/smbj/transport/PacketReader.java
@@ -15,6 +15,7 @@
  */
 package com.hierynomus.smbj.transport;
 
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -35,7 +36,11 @@ public abstract class PacketReader<D extends PacketData<?>> implements Runnable 
     private Thread thread;
 
     public PacketReader(String host, InputStream in, PacketReceiver<D> handler) {
-        this.in = in;
+    	if (in instanceof BufferedInputStream) {
+    		this.in = in;
+    	} else {
+    		this.in = new BufferedInputStream(in);
+    	}
         this.handler = handler;
         this.thread = new Thread(this, "Packet Reader for " + host);
         this.thread.setDaemon(true);

--- a/src/main/java/com/hierynomus/smbj/transport/PacketReader.java
+++ b/src/main/java/com/hierynomus/smbj/transport/PacketReader.java
@@ -36,11 +36,11 @@ public abstract class PacketReader<D extends PacketData<?>> implements Runnable 
     private Thread thread;
 
     public PacketReader(String host, InputStream in, PacketReceiver<D> handler) {
-    	if (in instanceof BufferedInputStream) {
-    		this.in = in;
-    	} else {
-    		this.in = new BufferedInputStream(in);
-    	}
+        if (in instanceof BufferedInputStream) {
+            this.in = in;
+        } else {
+            this.in = new BufferedInputStream(in);
+        }
         this.handler = handler;
         this.thread = new Thread(this, "Packet Reader for " + host);
         this.thread.setDaemon(true);


### PR DESCRIPTION
Currently the read from the socket is not buffered what can slow down reading bytes by byte.

This wraps the input stream in the PacketReader in a BufferedInputStream to read larger chuncks of data to improve performance.