### PR TITLE
Set sessionKey whenever we have it from authentication (Fixes #792)

### DIFF
--- a/src/main/java/com/hierynomus/smbj/connection/SMBSessionBuilder.java
+++ b/src/main/java/com/hierynomus/smbj/connection/SMBSessionBuilder.java
@@ -163,7 +163,7 @@ public class SMBSessionBuilder {
 
             SessionContext context = session.getSessionContext();
             processAuthenticationToken(ctx, response.getSecurityBuffer());
-            if (!ctx.authContext.isAnonymous() && !ctx.authContext.isGuest()) {
+            if (ctx.sessionKey != null) {
                 context.setSessionKey(new SecretKeySpec(ctx.sessionKey, HMAC_SHA256_ALGORITHM));
             }
             if (dialect == SMB2Dialect.SMB_3_1_1) {


### PR DESCRIPTION
This should fix the NPE that occurs when authenticating with guest or anonymous credentials and the server treating it as a regular account