### PR TITLE
Enforce security by default

### DIFF
--- a/src/main/java/com/hierynomus/smbj/SmbConfig.java
+++ b/src/main/java/com/hierynomus/smbj/SmbConfig.java
@@ -102,7 +102,7 @@ public final class SmbConfig {
                 .withClientGuid(UUID.randomUUID())
                 .withSecurityProvider(getDefaultSecurityProvider())
                 .withSocketFactory(new ProxySocketFactory())
-                .withSigningRequired(false)
+                .withSigningRequired(true)
                 .withDfsEnabled(false)
                 .withMultiProtocolNegotiate(false)
                 .withBufferSize(DEFAULT_BUFFER_SIZE)
@@ -113,7 +113,7 @@ public final class SmbConfig {
                 .withAuthenticators(getDefaultAuthenticators())
                 .withTimeout(DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_UNIT)
                 .withClientGSSContextConfig(GSSContextConfig.createDefaultConfig())
-                .withEncryptData(false);
+                .withEncryptData(true);
 
         return b;
     }


### PR DESCRIPTION
smbj by default does not require message signing and does not encrypt data. This could lead to program authors inadvertently writing insecure software.

The library should have secure defaults and allow users to reduce their security if they need.