### PR TITLE
Update third party dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
-BCPROV_JDK15ON=org.bouncycastle:bcprov-jdk18on:1.75
+BCPROV_JDK15ON=org.bouncycastle:bcprov-jdk18on:1.77
 CGLIB_NODEP=cglib:cglib-nodep:3.3.0
-COMMONS_IO=commons-io:commons-io:2.13.0
-LOGBACK_CLASSIC=ch.qos.logback:logback-classic:1.3.8
+COMMONS_IO=commons-io:commons-io:2.16.1
+LOGBACK_CLASSIC=ch.qos.logback:logback-classic:1.5.6
 MBASSADOR=net.engio:mbassador:1.3.0
-OBJENESIS=org.objenesis:objenesis:3.3
+OBJENESIS=org.objenesis:objenesis:3.4
 SLF4J_API=org.slf4j:slf4j-api:2.0.9
 SPOCK_CORE=org.spockframework:spock-core:2.3-groovy-3.0
 ASN_ONE=com.hierynomus:asn-one:0.6.0


### PR DESCRIPTION
Updates:
Bouncycastle to 1.77
commons-io to 2.16.1
logback-classic to 1.5.6
objenesis to 3.4