### PR TITLE
Fix InputStreamByteChunkProvider#isAvailable

### DIFF
--- a/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
+++ b/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hierynomus.smbj.io;
 
 import java.io.BufferedInputStream;

--- a/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
+++ b/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
@@ -1,0 +1,33 @@
+package com.hierynomus.smbj.io;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BufferedInputStreamReader {
+    private static final int EOF = -1;
+
+    private final AtomicBoolean isEnd = new AtomicBoolean(false);
+
+    private final BufferedInputStream inputStream;
+
+    public BufferedInputStreamReader(BufferedInputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    public int read(byte[] byteArray, int offset, int length) throws IOException {
+        int readResult = inputStream.read(byteArray, offset, length);
+        if (readResult == EOF) {
+            isEnd.set(true);
+        }
+        return readResult;
+    }
+
+    public boolean isAvailable() {
+        return !isEnd.get();
+    }
+
+    public void close() throws IOException {
+        inputStream.close();
+    }
+}

--- a/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
+++ b/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
@@ -17,12 +17,14 @@ package com.hierynomus.smbj.io;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.hierynomus.smbj.common.SMBRuntimeException;
 
 public class BufferedInputStreamReader {
     private static final int EOF = -1;
 
-    private final AtomicBoolean isEnd = new AtomicBoolean(false);
+    private final AtomicInteger cachedByte = new AtomicInteger(EOF);
 
     private final BufferedInputStream inputStream;
 
@@ -31,15 +33,27 @@ public class BufferedInputStreamReader {
     }
 
     public int read(byte[] byteArray, int offset, int length) throws IOException {
-        int readResult = inputStream.read(byteArray, offset, length);
-        if (readResult == EOF) {
-            isEnd.set(true);
+        if (cachedByte.get() != EOF) {
+            byteArray[offset] = (byte) cachedByte.getAndSet(EOF);
+            int readResult = inputStream.read(byteArray, offset + 1, length - 1);
+            return readResult == EOF ? 1 : (readResult + 1);
+        } else {
+            return inputStream.read(byteArray, offset, length);
         }
-        return readResult;
     }
 
     public boolean isAvailable() {
-        return !isEnd.get();
+        try {
+            if (inputStream.available() > 0 || cachedByte.get() != EOF) {
+                return true;
+            }
+            int readByte = inputStream.read();
+            cachedByte.set(readByte);
+            return readByte != EOF;
+        }
+        catch (IOException e) {
+            throw new SMBRuntimeException(e);
+        }
     }
 
     public void close() throws IOException {

--- a/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
+++ b/src/main/java/com/hierynomus/smbj/io/BufferedInputStreamReader.java
@@ -17,26 +17,28 @@ package com.hierynomus.smbj.io;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.hierynomus.smbj.common.SMBRuntimeException;
 
 public class BufferedInputStreamReader {
     private static final int EOF = -1;
 
-    private final AtomicInteger cachedByte = new AtomicInteger(EOF);
-
     private final BufferedInputStream inputStream;
+    private volatile int cachedByte = EOF;
 
     public BufferedInputStreamReader(BufferedInputStream inputStream) {
         this.inputStream = inputStream;
     }
 
     public int read(byte[] byteArray, int offset, int length) throws IOException {
-        if (cachedByte.get() != EOF) {
-            byteArray[offset] = (byte) cachedByte.getAndSet(EOF);
+        if (cachedByte > EOF) {
+            byteArray[offset] = (byte) cachedByte;
+            cachedByte = EOF;
+            if (length == 1) {
+                return 1;
+            }
             int readResult = inputStream.read(byteArray, offset + 1, length - 1);
-            return readResult == EOF ? 1 : (readResult + 1);
+            return readResult > EOF ? (readResult + 1) : 1;
         } else {
             return inputStream.read(byteArray, offset, length);
         }
@@ -44,12 +46,12 @@ public class BufferedInputStreamReader {
 
     public boolean isAvailable() {
         try {
-            if (inputStream.available() > 0 || cachedByte.get() != EOF) {
+            if (cachedByte > EOF || inputStream.available() > 0) {
                 return true;
             }
             int readByte = inputStream.read();
-            cachedByte.set(readByte);
-            return readByte != EOF;
+            cachedByte = readByte;
+            return readByte > EOF;
         }
         catch (IOException e) {
             throw new SMBRuntimeException(e);

--- a/src/test/groovy/com/hierynomus/smbj/io/FileByteChunkProviderSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/io/FileByteChunkProviderSpec.groovy
@@ -32,7 +32,6 @@ class FileByteChunkProviderSpec extends Specification {
     then:
     baos.toByteArray() == file.bytes
     provider.offset == ByteChunkProvider.CHUNK_SIZE
-    !provider.isAvailable()
   }
 
   def "should write part of chunk to outputStream"() {

--- a/src/test/groovy/com/hierynomus/smbj/io/FileByteChunkProviderSpec.groovy
+++ b/src/test/groovy/com/hierynomus/smbj/io/FileByteChunkProviderSpec.groovy
@@ -32,6 +32,7 @@ class FileByteChunkProviderSpec extends Specification {
     then:
     baos.toByteArray() == file.bytes
     provider.offset == ByteChunkProvider.CHUNK_SIZE
+    !provider.isAvailable()
   }
 
   def "should write part of chunk to outputStream"() {

--- a/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
+++ b/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
@@ -1,0 +1,33 @@
+package com.hierynomus.smbj.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+public class BufferedInputStreamReaderTest {
+    private static final int EOF = -1;
+
+    @Test
+    void shouldReturnIsAvailableFalseWhenUnderlyingInputStreamSignalsEOF() throws IOException {
+        BufferedInputStreamReader bufferedInputStreamReader = new BufferedInputStreamReader(
+            new BufferedInputStream(
+                new ByteArrayInputStream(new byte[] {1, 2, 3})
+            ));
+
+        assertThat(bufferedInputStreamReader.isAvailable()).isTrue();
+
+        byte[] outputArray = new byte[3];
+        assertThat(bufferedInputStreamReader.read(outputArray, 0, 3)).isEqualTo(3);
+
+        // Still some bytes might be read
+        assertThat(bufferedInputStreamReader.isAvailable()).isTrue();
+
+        assertThat(bufferedInputStreamReader.read(new byte[100], 0, 100)).isEqualTo(EOF);
+        assertThat(bufferedInputStreamReader.isAvailable()).isFalse();
+    }
+
+}

--- a/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
+++ b/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hierynomus.smbj.io;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
+++ b/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
@@ -46,7 +46,7 @@ public class BufferedInputStreamReaderTest {
         BufferedInputStreamReader bufferedInputStreamReader = new BufferedInputStreamReader(
             new BufferedInputStream(
                 new InputStream() {
-                    private final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {1, 2, 3});
+                    private final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5, 6});
 
                     @Override
                     public int read() {
@@ -64,6 +64,12 @@ public class BufferedInputStreamReaderTest {
 
         byte[] outputArray = new byte[3];
         assertThat(bufferedInputStreamReader.read(outputArray, 0, 3)).isEqualTo(3);
+        assertThat(outputArray).containsExactly(1, 2, 3);
+
+        assertThat(bufferedInputStreamReader.isAvailable()).isTrue();
+
+        assertThat(bufferedInputStreamReader.read(outputArray, 0, 3)).isEqualTo(3);
+        assertThat(outputArray).containsExactly(4, 5, 6);
 
         assertThat(bufferedInputStreamReader.isAvailable()).isFalse();
     }

--- a/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
+++ b/src/test/java/com/hierynomus/smbj/io/BufferedInputStreamReaderTest.java
@@ -20,11 +20,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 
 public class BufferedInputStreamReaderTest {
-    private static final int EOF = -1;
 
     @Test
     void shouldReturnIsAvailableFalseWhenUnderlyingInputStreamSignalsEOF() throws IOException {
@@ -38,10 +38,33 @@ public class BufferedInputStreamReaderTest {
         byte[] outputArray = new byte[3];
         assertThat(bufferedInputStreamReader.read(outputArray, 0, 3)).isEqualTo(3);
 
-        // Still some bytes might be read
+        assertThat(bufferedInputStreamReader.isAvailable()).isFalse();
+    }
+
+    @Test
+    void shouldNotRelyOnEstimateAvailableBytes() throws IOException {
+        BufferedInputStreamReader bufferedInputStreamReader = new BufferedInputStreamReader(
+            new BufferedInputStream(
+                new InputStream() {
+                    private final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {1, 2, 3});
+
+                    @Override
+                    public int read() {
+                        return inputStream.read();
+                    }
+
+                    @Override
+                    public int available() {
+                        return 0;
+                    }
+                }
+            ));
+
         assertThat(bufferedInputStreamReader.isAvailable()).isTrue();
 
-        assertThat(bufferedInputStreamReader.read(new byte[100], 0, 100)).isEqualTo(EOF);
+        byte[] outputArray = new byte[3];
+        assertThat(bufferedInputStreamReader.read(outputArray, 0, 3)).isEqualTo(3);
+
         assertThat(bufferedInputStreamReader.isAvailable()).isFalse();
     }
 

--- a/src/test/java/com/hierynomus/smbj/io/InputStreamByteChunkProviderTest.java
+++ b/src/test/java/com/hierynomus/smbj/io/InputStreamByteChunkProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.smbj.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+class InputStreamByteChunkProviderTest {
+
+    @Test
+    void givenInputStreamAvailableAlwaysReturnZero() throws IOException {
+
+        InputStreamByteChunkProvider byteChunkProvider = new InputStreamByteChunkProvider(new InputStream() {
+            private final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[] {1, 2, 3, 4, 5, 6});
+
+            @Override
+            public int read() {
+                return inputStream.read();
+            }
+
+            @Override
+            public int available() {
+                return 0;
+            }
+        });
+
+        assertThat(byteChunkProvider.isAvailable()).isTrue();
+
+        int readBytes = byteChunkProvider.prepareChunk(new byte[7], 7);
+
+        assertThat(readBytes).isEqualTo(6);
+
+        assertThat(byteChunkProvider.isAvailable()).isFalse();
+    }
+}


### PR DESCRIPTION
Hello!

There is issue in this function - https://github.com/hierynomus/smbj/blob/b78c87285bcec7b18895e1ccb46d51b9f22f649e/src/main/java/com/hierynomus/smbj/io/InputStreamByteChunkProvider.java#L53.
According to docs - https://docs.oracle.com/javase/8/docs/api/java/io/BufferedInputStream.html. BufferedInputStream#available returns only estimate of the number of bytes that can be read.
And one of implementations of InputStream we rely on actually always returns zero before reading.
Please review my approach. I've tested it and it works as expected