### PR TITLE
Feature/filesystem over dfs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ testing {
         runtimeOnly OBJENESIS
         implementation SPOCK_CORE
         implementation COMMONS_IO
+        implementation platform('org.junit:junit-bom:5.14.4')
         implementation enforcedPlatform("org.mockito:mockito-bom:5.4.0")
         implementation "org.mockito:mockito-core"
         implementation "org.mockito:mockito-junit-jupiter"
@@ -132,6 +133,7 @@ testing {
       dependencies {
         implementation project()
         implementation "ch.qos.logback:logback-classic:1.3.8"
+        implementation platform('org.junit:junit-bom:5.14.4')
         implementation platform('org.testcontainers:testcontainers-bom:2.0.5')
         implementation 'org.testcontainers:testcontainers'
         implementation 'org.testcontainers:testcontainers-junit-jupiter'

--- a/build.gradle
+++ b/build.gradle
@@ -127,8 +127,9 @@ testing {
       dependencies {
         implementation project()
         implementation "ch.qos.logback:logback-classic:1.3.8"
-        implementation 'org.testcontainers:testcontainers:1.19.0'
-        implementation 'org.testcontainers:junit-jupiter:1.19.0'
+        implementation platform('org.testcontainers:testcontainers-bom:2.0.5')
+        implementation 'org.testcontainers:testcontainers'
+        implementation 'org.testcontainers:testcontainers-junit-jupiter'
         implementation 'org.apache.commons:commons-compress:1.24.0'
       }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
-import com.bmuschko.gradle.docker.tasks.container.*
-import com.bmuschko.gradle.docker.tasks.image.*
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
 plugins {
   id "java"
@@ -13,6 +12,7 @@ plugins {
   // id 'ru.vyarus.java-lib' version '2.1.0'
   id 'ru.vyarus.github-info' version '1.5.0'
   id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
+  id 'com.bmuschko.docker-remote-api' version '9.4.0'
 }
 
 group = "com.hierynomus"
@@ -84,6 +84,11 @@ if (JavaVersion.current().isJava8Compatible()) {
   }
 }
 
+def buildImageTask = tasks.register('buildSambaImage', DockerBuildImage) {
+  inputDir = file('src/it/docker-image')
+  images.add('smbj/samba:latest')
+}
+
 testing {
   suites {
     configureEach {
@@ -149,6 +154,7 @@ testing {
       targets {
         all {
           testTask.configure {
+            dependsOn(buildImageTask)
             shouldRunAfter(test)
           }
         }

--- a/src/it/java/com/hierynomus/smbj/testcontainers/SambaContainer.java
+++ b/src/it/java/com/hierynomus/smbj/testcontainers/SambaContainer.java
@@ -15,8 +15,6 @@
  */
 package com.hierynomus.smbj.testcontainers;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.SmbConfig;
 import com.hierynomus.smbj.auth.AuthenticationContext;
@@ -24,18 +22,11 @@ import com.hierynomus.smbj.connection.Connection;
 import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.testing.TestingUtils.ConsumerWithError;
 import org.apache.commons.io.IOUtils;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.builder.ImageFromDockerfile;
-import org.testcontainers.images.builder.dockerfile.DockerfileBuilder;
-import org.testcontainers.utility.DockerLoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
-import java.util.concurrent.Future;
-import java.util.function.Consumer;
 
 import static com.hierynomus.smbj.testing.TestingUtils.PASSWORD;
 import static com.hierynomus.smbj.testing.TestingUtils.USER;
@@ -43,63 +34,10 @@ import static java.nio.charset.Charset.defaultCharset;
 
 public class SambaContainer extends GenericContainer<SambaContainer> {
 
-    public static final SambaContainer INSTANCE = new SambaContainer.Builder().build();
+    public static final SambaContainer INSTANCE = new SambaContainer();
 
-    /**
-     * A workaround for strange logger names of testcontainers. They contain no
-     * dots, but contain slashes,
-     * square brackets, and even emoji. It's uneasy to set the logging level via the
-     * XML file of logback, the
-     * result would be less readable than the code below.
-     */
-    public static class DebugLoggingImageFromDockerfile extends ImageFromDockerfile {
-        public DebugLoggingImageFromDockerfile() {
-            super();
-            Logger logger = (Logger) LoggerFactory.getILoggerFactory()
-                    .getLogger(DockerLoggerFactory.getLogger(getDockerImageName()).getName());
-            logger.setLevel(Level.DEBUG);
-        }
-    }
-
-    public static class Builder implements Consumer<DockerfileBuilder> {
-        @Override
-        public void accept(DockerfileBuilder t) {
-            t.from("alpine:3.18.3");
-            t.run("apk update && apk add --no-cache tini samba samba-common-tools supervisor bash");
-            t.env("SMB_USER", "smbj");
-            t.env("SMB_PASSWORD", "smbj");
-            t.copy("smb.conf", "/etc/samba/smb.conf");
-            t.copy("supervisord.conf", "/etc/supervisord.conf");
-            t.copy("entrypoint.sh", "/entrypoint.sh");
-            t.add("public", "/opt/samba/share");
-            t.run("mkdir -p /opt/samba/readonly /opt/samba/user /opt/samba/dfs"
-                    + " && chmod 777 /opt/samba/readonly /opt/samba/user /opt/samba/dfs"
-                    + " && adduser -s /bin/false $SMB_USER -D $SMB_PASSWORD"
-                    + " && (echo $SMB_PASSWORD; echo $SMB_PASSWORD ) | pdbedit -a -u $SMB_USER"
-                    + " && chmod ugo+x /entrypoint.sh");
-            t.expose(445);
-            t.entryPoint("/sbin/tini", "/entrypoint.sh");
-            t.cmd("supervisord");
-        }
-
-        public SambaContainer build() {
-            return new SambaContainer(buildInner());
-        }
-
-        Future<String> buildInner() {
-            return new DebugLoggingImageFromDockerfile()
-                    .withDockerfileFromBuilder(this)
-                    .withFileFromPath(".", Paths.get("src/it/docker-image"));
-        }
-    }
-
-
-    public SambaContainer(SambaContainer.Builder builder) {
-        this(builder.buildInner());
-    }
-
-    public SambaContainer(Future<String> imageName) {
-        super(imageName);
+    public SambaContainer() {
+        super("smbj/samba");
         withExposedPorts(445);
         addFixedExposedPort(445, 445);
         setWaitStrategy(Wait.forListeningPort());

--- a/src/it/java/com/hierynomus/smbj/testcontainers/SambaContainer.java
+++ b/src/it/java/com/hierynomus/smbj/testcontainers/SambaContainer.java
@@ -20,6 +20,7 @@ import com.hierynomus.smbj.SmbConfig;
 import com.hierynomus.smbj.auth.AuthenticationContext;
 import com.hierynomus.smbj.connection.Connection;
 import com.hierynomus.smbj.session.Session;
+import com.hierynomus.smbj.testing.TestingUtils;
 import com.hierynomus.smbj.testing.TestingUtils.ConsumerWithError;
 import org.apache.commons.io.IOUtils;
 import org.testcontainers.containers.GenericContainer;
@@ -28,8 +29,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import java.io.IOException;
 import java.net.URI;
 
-import static com.hierynomus.smbj.testing.TestingUtils.PASSWORD;
-import static com.hierynomus.smbj.testing.TestingUtils.USER;
 import static java.nio.charset.Charset.defaultCharset;
 
 public class SambaContainer extends GenericContainer<SambaContainer> {
@@ -75,11 +74,16 @@ public class SambaContainer extends GenericContainer<SambaContainer> {
     }
 
     public URI publicUri() {
-        return URI.create("smb://" + USER + ":" + PASSWORD + "@" + getHost() + ":" + getFirstMappedPort() + "/public/");
+        return shareUri("public");
     }
 
     public URI userUri() {
-        return URI.create("smb://" + USER + ":" + PASSWORD + "@" + getHost() + ":" + getFirstMappedPort() + "/user/");
+        return shareUri("user");
+    }
+
+    public URI shareUri(String share) {
+        return URI.create("smb://" + TestingUtils.USER + ":" + TestingUtils.PASSWORD + "@" + getHost() + ":" + getFirstMappedPort() + "/")
+            .resolve(share + "/");
     }
 
     public String readFileFromContainer(String file) {

--- a/src/it/java/integration/smbfs/DirectoryCreationIntegrationTest.java
+++ b/src/it/java/integration/smbfs/DirectoryCreationIntegrationTest.java
@@ -15,37 +15,44 @@
  */
 package integration.smbfs;
 
-import com.hierynomus.smbfs.SmbFileSystem;
-import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static java.util.Collections.emptyMap;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 
+@ParameterizedClass
+@MethodSource("integration.smbfs.TestShares#allUserShares")
 @Testcontainers
 class DirectoryCreationIntegrationTest {
 
     @Container
     private static final SambaContainer samba = SambaContainer.INSTANCE;
 
-    private SmbFileSystemProvider provider;
+    private final String share;
 
-    @BeforeEach
-    void setUp() {
-        provider = new SmbFileSystemProvider();
+    DirectoryCreationIntegrationTest(String share) {
+        this.share = share;
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        samba.deleteFromContainer("/opt/samba/user/a");
     }
 
     @Test
     void createsDirectory() throws Exception {
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
 
-            SmbPath path = fileSystem.getPath("a");
-            fileSystem.provider().createDirectory(path);
-        }
+        withFileSystemProvider(samba, share, (provider, base) -> {
+
+            SmbPath path = base.resolve("a");
+            provider.createDirectory(path);
+        });
 
         samba.dirExistsInContainer("/opt/samba/user/a");
     }

--- a/src/it/java/integration/smbfs/DirectoryListingIntegrationTest.java
+++ b/src/it/java/integration/smbfs/DirectoryListingIntegrationTest.java
@@ -20,6 +20,9 @@ import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -28,8 +31,10 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
@@ -60,22 +65,27 @@ class DirectoryListingIntegrationTest {
         }
     }
 
-    @Test
-    void listsDirectories() throws Exception {
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap())) {
+    static Stream<Arguments> listDirectoriesArguments() {
+        return  Stream.of(
+            Arguments.arguments("public", List.of("\\folder", "\\test.txt")),
+            Arguments.arguments("dfs/public", List.of("\\public\\folder", "\\public\\test.txt"))
 
-            List<String> actual = list(rootDirectory(fileSystem));
-
-            List<String> expected = List.of("\\folder", "\\test.txt");
-            assertEquals(expected, actual);
-        }
+        );
     }
 
-    private static Path rootDirectory(SmbFileSystem fileSystem) {
-        return fileSystem.getRootDirectories().iterator().next();
+    @ParameterizedTest
+    @MethodSource("listDirectoriesArguments")
+    void listsDirectories(String share, List<String> contents) throws Exception {
+
+        withFileSystemProvider(samba, share, (provider, base) -> {
+
+            List<String> actual = list(provider, base);
+
+            assertEquals(contents, actual);
+        });
     }
 
-    private List<String> list(Path path) throws IOException {
+    private List<String> list(SmbFileSystemProvider provider, Path path) throws IOException {
         try (DirectoryStream<Path> stream = provider.newDirectoryStream(path, f -> true)) {
             return StreamSupport.stream(stream.spliterator(), false)
                 .map(Path::toString)

--- a/src/it/java/integration/smbfs/FileAccessIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileAccessIntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package integration.smbfs;
 
-import com.hierynomus.smbfs.SmbFileSystem;
-import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,21 +27,22 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyMap;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+@ParameterizedClass
+@MethodSource("integration.smbfs.TestShares#allPublicShares")
 @Testcontainers
 class FileAccessIntegrationTest {
 
     @Container
     private static final SambaContainer samba = SambaContainer.INSTANCE;
 
-    private SmbFileSystemProvider provider;
+    private final String share;
 
-    @BeforeEach
-    void setUp() {
-        provider = new SmbFileSystemProvider();
+    FileAccessIntegrationTest(String share) {
+        this.share = share;
     }
 
     static Stream<Arguments> filesThatExist() {
@@ -58,12 +57,12 @@ class FileAccessIntegrationTest {
     @MethodSource("filesThatExist")
     void fileExists(String path) throws Exception {
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path1 = fileSystem.getPath(path);
+            SmbPath path1 = base.resolve(path);
 
             provider.checkAccess(path1);
-        }
+        });
     }
 
     static Stream<Arguments> filesThatDontExist() {
@@ -77,10 +76,10 @@ class FileAccessIntegrationTest {
     @MethodSource("filesThatDontExist")
     void fileMissing(String path) throws Exception {
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path1 = fileSystem.getPath(path);
+            SmbPath path1 = base.resolve(path);
             assertThrows(IOException.class, () -> provider.checkAccess(path1));
-        }
+        });
     }
 }

--- a/src/it/java/integration/smbfs/FileAttributesIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileAttributesIntegrationTest.java
@@ -15,41 +15,41 @@
  */
 package integration.smbfs;
 
-import com.hierynomus.smbfs.SmbFileSystem;
-import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.file.attribute.BasicFileAttributes;
 
-import static java.util.Collections.emptyMap;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ParameterizedClass
+@MethodSource("integration.smbfs.TestShares#allPublicShares")
 @Testcontainers
 class FileAttributesIntegrationTest {
 
     @Container
     private static final SambaContainer samba = SambaContainer.INSTANCE;
 
-    private SmbFileSystemProvider provider;
+    private final String share;
 
-    @BeforeEach
-    void setUp() {
-        provider = new SmbFileSystemProvider();
+    FileAttributesIntegrationTest(String share) {
+        this.share = share;
     }
 
     @Test
     void readsFileAttributes() throws Exception {
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path = fileSystem.getPath("test.txt");
+            SmbPath path = base.resolve("test.txt");
             BasicFileAttributes attrs = provider.readAttributes(path, BasicFileAttributes.class);
 
             assertTrue(attrs.isRegularFile());
@@ -57,14 +57,14 @@ class FileAttributesIntegrationTest {
             assertFalse(attrs.isSymbolicLink());
             assertEquals(10, attrs.size());
             assertNull(attrs.fileKey());
-        }
+        });
     }
 
     @Test
     void readsDirectoryAttributes() throws Exception {
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap())) {
 
-            SmbPath path = fileSystem.getPath("folder");
+        withFileSystemProvider(samba, share, (provider, base) -> {
+            SmbPath path = base.resolve("folder");
             BasicFileAttributes attrs = provider.readAttributes(path, BasicFileAttributes.class);
 
             assertFalse(attrs.isRegularFile());
@@ -72,6 +72,6 @@ class FileAttributesIntegrationTest {
             assertFalse(attrs.isSymbolicLink());
             assertEquals(0, attrs.size());
             assertNull(attrs.fileKey());
-        }
+        });
     }
 }

--- a/src/it/java/integration/smbfs/FileCopyIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileCopyIntegrationTest.java
@@ -21,12 +21,17 @@ import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static integration.smbfs.RandomData.randomString;
+import static integration.smbfs.TestShares.withFileSystem;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -66,22 +71,36 @@ public class FileCopyIntegrationTest {
         assertEquals(data, samba.readFileFromContainer("/opt/samba/user/target.txt"));
     }
 
-    @Test
-    void copiesFileOnDifferentShares() throws Exception {
+    @Nested
+    @ParameterizedClass
+    @MethodSource("integration.smbfs.TestShares#allPublicToUserShares")
+    class WithDifferentShares {
 
-        String data = randomString(33);
-        Transferable transferable = Transferable.of(data);
-        samba.copyFileToContainer(transferable, "/opt/samba/share/source.txt");
+        private final String publicShare;
+        private final String userShare;
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap());
-             SmbFileSystem targetFileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
-
-            SmbPath source = fileSystem.getPath("source.txt");
-            SmbPath target = targetFileSystem.getPath("target.txt");
-
-            fileSystem.provider().copy(source, target);
+        WithDifferentShares(String publicShare, String userShare) {
+            this.publicShare = publicShare;
+            this.userShare = userShare;
         }
 
-        assertEquals(data, samba.readFileFromContainer("/opt/samba/user/target.txt"));
+        @Test
+        void copiesFileOnDifferentShares() throws Exception {
+
+            String data = randomString(33);
+            Transferable transferable = Transferable.of(data);
+            samba.copyFileToContainer(transferable, "/opt/samba/share/source.txt");
+
+            withFileSystemProvider(samba, publicShare, (provider, publicBase) -> {
+                withFileSystem(provider, samba, userShare, (ignored, userBase) -> {
+                    SmbPath source = publicBase.resolve("source.txt");
+                    SmbPath target = userBase.resolve("target.txt");
+
+                    provider.copy(source, target);
+                });
+            });
+
+            assertEquals(data, samba.readFileFromContainer("/opt/samba/user/target.txt"));
+        }
     }
 }

--- a/src/it/java/integration/smbfs/FileDeleteIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileDeleteIntegrationTest.java
@@ -15,35 +15,39 @@
  */
 package integration.smbfs;
 
-import com.hierynomus.smbfs.SmbFileSystem;
-import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static integration.smbfs.RandomData.randomString;
-import static java.util.Collections.emptyMap;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ParameterizedClass
+@MethodSource("integration.smbfs.TestShares#allUserShares")
 @Testcontainers
 public class FileDeleteIntegrationTest {
 
     @Container
     private static final SambaContainer samba = SambaContainer.INSTANCE;
 
-    private SmbFileSystemProvider provider;
+    private final String share;
+
+    FileDeleteIntegrationTest(String share) {
+        this.share = share;
+    }
 
     @BeforeEach
     void setUp() throws Exception {
         samba.mkdirInContainer("/opt/samba/user/a");
-
-        provider = new SmbFileSystemProvider();
     }
 
     @AfterEach
@@ -62,10 +66,10 @@ public class FileDeleteIntegrationTest {
         Transferable transferable = Transferable.of(data);
         samba.copyFileToContainer(transferable, "/opt/samba/user/" + file);
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
-            SmbPath path = fileSystem.getPath(file);
-            fileSystem.provider().delete(path);
-        }
+        withFileSystemProvider(samba, share, (provider, base) -> {
+            SmbPath path = base.resolve(file);
+            provider.delete(path);
+        });
 
         assertFalse(samba.fileExistsInContainer("/opt/samba/user/" + file));
     }

--- a/src/it/java/integration/smbfs/FileMoveIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileMoveIntegrationTest.java
@@ -22,14 +22,19 @@ import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static integration.smbfs.RandomData.randomString;
+import static integration.smbfs.TestShares.withFileSystem;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -104,22 +109,37 @@ public class FileMoveIntegrationTest {
         }
     }
 
-    @Test
-    void movesFilesOnDifferentShares() throws Exception {
+    @Nested
+    @ParameterizedClass
+    @MethodSource("integration.smbfs.TestShares#allPublicToUserShares")
+    class WithDifferentShares {
 
-        String data = randomString(23);
-        Transferable transferable = Transferable.of(data);
-        samba.copyFileToContainer(transferable, "/opt/samba/share/source.txt");
+        private final String publicShare;
+        private final String userShare;
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap());
-             SmbFileSystem targetFileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
-
-            SmbPath source = fileSystem.getPath("source.txt");
-            SmbPath target = targetFileSystem.getPath("target.txt");
-            fileSystem.provider().move(source, target);
+        WithDifferentShares(String publicShare, String userShare) {
+            this.publicShare = publicShare;
+            this.userShare = userShare;
         }
 
-        assertEquals(data, samba.readFileFromContainer("/opt/samba/user/target.txt"));
-        assertFalse(samba.fileExistsInContainer("/opt/samba/share/source.txt"));
+        @Test
+        void movesFilesOnDifferentShares() throws Exception {
+
+            String data = randomString(23);
+            Transferable transferable = Transferable.of(data);
+            samba.copyFileToContainer(transferable, "/opt/samba/share/source.txt");
+
+            withFileSystemProvider(samba, publicShare, (provider, publicBase) -> {
+                withFileSystem(provider, samba, userShare, (ignored, userBase) -> {
+
+                    SmbPath source = publicBase.resolve("source.txt");
+                    SmbPath target = userBase.resolve("target.txt");
+                    provider.move(source, target);
+                });
+            });
+
+            assertEquals(data, samba.readFileFromContainer("/opt/samba/user/target.txt"));
+            assertFalse(samba.fileExistsInContainer("/opt/samba/share/source.txt"));
+        }
     }
 }

--- a/src/it/java/integration/smbfs/FileReadingIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileReadingIntegrationTest.java
@@ -15,39 +15,40 @@
  */
 package integration.smbfs;
 
-import com.hierynomus.smbfs.SmbFileSystem;
-import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static java.util.Collections.emptyMap;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ParameterizedClass
+@MethodSource("integration.smbfs.TestShares#allPublicShares")
 @Testcontainers
 class FileReadingIntegrationTest {
 
     @Container
     private static final SambaContainer samba = SambaContainer.INSTANCE;
-    private SmbFileSystemProvider provider;
 
-    @BeforeEach
-    void setUp() {
-        provider = new SmbFileSystemProvider();
+    private final String share;
+
+    FileReadingIntegrationTest(String share) {
+        this.share = share;
     }
 
     @Test
     void readsFile() throws Exception {
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.publicUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path = fileSystem.getPath("test.txt");
+            SmbPath path = base.resolve("test.txt");
 
             try (InputStream in = provider.newInputStream(path)) {
 
@@ -55,6 +56,6 @@ class FileReadingIntegrationTest {
 
                 assertEquals("Hi there!\n", new String(bytes, StandardCharsets.UTF_8));
             }
-        }
+        });
     }
 }

--- a/src/it/java/integration/smbfs/FileWritingIntegrationTest.java
+++ b/src/it/java/integration/smbfs/FileWritingIntegrationTest.java
@@ -15,13 +15,12 @@
  */
 package integration.smbfs;
 
-import com.hierynomus.smbfs.SmbFileSystem;
-import com.hierynomus.smbfs.SmbFileSystemProvider;
 import com.hierynomus.smbfs.SmbPath;
 import com.hierynomus.smbj.testcontainers.SambaContainer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -31,20 +30,21 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardOpenOption;
 
 import static integration.smbfs.RandomData.randomString;
-import static java.util.Collections.emptyMap;
+import static integration.smbfs.TestShares.withFileSystemProvider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ParameterizedClass
+@MethodSource("integration.smbfs.TestShares#allUserShares")
 @Testcontainers
-public class FileWritingIntegrationTest {
+class FileWritingIntegrationTest {
 
     @Container
     private static final SambaContainer samba = SambaContainer.INSTANCE;
 
-    private SmbFileSystemProvider provider;
+    private final String share;
 
-    @BeforeEach
-    void setUp() {
-        provider = new SmbFileSystemProvider();
+    FileWritingIntegrationTest(String share) {
+        this.share = share;
     }
 
     @AfterEach
@@ -58,14 +58,14 @@ public class FileWritingIntegrationTest {
 
         String data = randomString(23);
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path = fileSystem.getPath("written.txt");
+            SmbPath path = base.resolve("written.txt");
 
             try (OutputStream out = provider.newOutputStream(path)) {
                 out.write(data.trim().getBytes(StandardCharsets.UTF_8));
             }
-        }
+        });
 
         assertEquals(data, samba.readFileFromContainer("/opt/samba/user/written.txt"));
     }
@@ -75,14 +75,14 @@ public class FileWritingIntegrationTest {
 
         String data = randomString(23);
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path = fileSystem.getPath("written.txt");
+            SmbPath path = base.resolve("written.txt");
 
             try (OutputStream out = provider.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
                 out.write(data.getBytes(StandardCharsets.UTF_8));
             }
-        }
+        });
 
         assertEquals(data, samba.readFileFromContainer("/opt/samba/user/written.txt"));
     }
@@ -98,14 +98,14 @@ public class FileWritingIntegrationTest {
         //noinspection OctalInteger
         samba.copyFileToContainer(Transferable.of(initialData, 0100666), containerPath);
 
-        try (SmbFileSystem fileSystem = provider.newFileSystem(samba.userUri(), emptyMap())) {
+        withFileSystemProvider(samba, share, (provider, base) -> {
 
-            SmbPath path = fileSystem.getPath("test.txt");
+            SmbPath path = base.resolve("test.txt");
 
             try (OutputStream out = provider.newOutputStream(path, StandardOpenOption.APPEND)) {
                 out.write(additionalData.getBytes(StandardCharsets.UTF_8));
             }
-        }
+        });
 
         assertEquals(initialData + additionalData, samba.readFileFromContainer(containerPath));
     }

--- a/src/it/java/integration/smbfs/TestShares.java
+++ b/src/it/java/integration/smbfs/TestShares.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C)2016 - SMBJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package integration.smbfs;
+
+import com.hierynomus.smbfs.SmbFileSystem;
+import com.hierynomus.smbfs.SmbFileSystemProvider;
+import com.hierynomus.smbfs.SmbPath;
+import com.hierynomus.smbj.testcontainers.SambaContainer;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class TestShares {
+
+    static Stream<String> allPublicShares() {
+        return Stream.of(
+            "public",
+            "dfs/public"
+        );
+    }
+
+    static Stream<String> allUserShares() {
+        return Stream.of(
+            "user",
+            "dfs/user"
+        );
+    }
+
+    static Stream<Arguments> allPublicToUserShares() {
+        return Stream.of(
+            arguments("public", "user"),
+            arguments("public", "dfs/user"),
+            arguments("dfs/public", "user")
+            // This doesn't work at the moment for moving & copying files
+            // arguments("dfs/public", "dfs/user")
+        );
+    }
+
+    private TestShares() {
+    }
+
+    static void withFileSystemProvider(SambaContainer samba, String share,
+                                       BiConsumerWithError<SmbFileSystemProvider, SmbPath> with) throws Exception {
+
+        SmbFileSystemProvider provider = new SmbFileSystemProvider();
+        withFileSystem(provider, samba, share, with);
+    }
+
+    static void withFileSystem(SmbFileSystemProvider provider, SambaContainer samba, String share,
+                               BiConsumerWithError<SmbFileSystemProvider, SmbPath> with)
+        throws Exception {
+        URI uri = samba.shareUri(share);
+        try (SmbFileSystem ignored = getOrNewFileSystem(provider, uri, emptyMap())) {
+            with.with(provider, provider.getPath(uri));
+        }
+    }
+
+    // temporary method to get integration tests working
+    private static SmbFileSystem getOrNewFileSystem(SmbFileSystemProvider provider, URI uri, Map<String, ?> env) throws IOException {
+        try {
+            return provider.newFileSystem(uri, env);
+        } catch (FileSystemAlreadyExistsException e) {
+            return provider.getFileSystem(uri);
+        }
+    }
+
+    @FunctionalInterface
+    interface BiConsumerWithError<T, U> {
+        void with(T provider, U path) throws Exception;
+    }
+}
+

--- a/src/it/java/integration/smbfs/TestShares.java
+++ b/src/it/java/integration/smbfs/TestShares.java
@@ -27,6 +27,7 @@ import java.nio.file.FileSystemAlreadyExistsException;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static com.hierynomus.smbfs.SmbFileSystemProvider.DFS_ENABLED_PROPERTY;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -70,7 +71,10 @@ class TestShares {
                                BiConsumerWithError<SmbFileSystemProvider, SmbPath> with)
         throws Exception {
         URI uri = samba.shareUri(share);
-        try (SmbFileSystem ignored = getOrNewFileSystem(provider, uri, emptyMap())) {
+        Map<String, Object> env = share.startsWith("dfs/")
+            ? Map.of(DFS_ENABLED_PROPERTY, true)
+            : emptyMap();
+        try (SmbFileSystem ignored = getOrNewFileSystem(provider, uri, env)) {
             with.with(provider, provider.getPath(uri));
         }
     }

--- a/src/main/java/com/hierynomus/smbfs/SmbFileSystemProvider.java
+++ b/src/main/java/com/hierynomus/smbfs/SmbFileSystemProvider.java
@@ -16,6 +16,7 @@
 package com.hierynomus.smbfs;
 
 import com.hierynomus.smbj.SMBClient;
+import com.hierynomus.smbj.SmbConfig;
 import com.hierynomus.smbj.auth.AuthenticationContext;
 
 import java.io.IOException;
@@ -157,7 +158,7 @@ public class SmbFileSystemProvider extends FileSystemProvider {
 
     private String extractDomain(AuthenticationContext uriAuth, Map<String, ?> env) {
         if (env.containsKey(DOMAIN_PROPERTY)) {
-            return (String)env.get(DOMAIN_PROPERTY);
+            return (String) env.get(DOMAIN_PROPERTY);
         }
 
         return uriAuth.getDomain();
@@ -165,7 +166,7 @@ public class SmbFileSystemProvider extends FileSystemProvider {
 
     private String extractUser(AuthenticationContext uriAuth, Map<String, ?> env) {
         if (env.containsKey(USERNAME_PROPERTY)) {
-            return (String)env.get(USERNAME_PROPERTY);
+            return (String) env.get(USERNAME_PROPERTY);
         }
 
         return uriAuth.getUsername();
@@ -365,7 +366,11 @@ public class SmbFileSystemProvider extends FileSystemProvider {
         public SmbFileSystem create(SmbFileSystemProvider provider, String host, int port,
                                     AuthenticationContext context, String shareName) {
 
-            ShareSourceImpl shares = new ShareSourceImpl(new SMBClient(), host, port, context);
+            SmbConfig config = SmbConfig.builder()
+                .withDfsEnabled(true)
+                .build();
+
+            ShareSourceImpl shares = new ShareSourceImpl(new SMBClient(config), host, port, context);
 
             return new SmbFileSystem(provider, shares, shareName);
         }

--- a/src/main/java/com/hierynomus/smbfs/SmbFileSystemProvider.java
+++ b/src/main/java/com/hierynomus/smbfs/SmbFileSystemProvider.java
@@ -49,6 +49,7 @@ public class SmbFileSystemProvider extends FileSystemProvider {
     public static final String DOMAIN_PROPERTY = "smbfs.domain";
     public static final String USERNAME_PROPERTY = "smbfs.username";
     public static final String PASSWORD_PROPERTY = "smbfs.password";
+    public static final String DFS_ENABLED_PROPERTY = "smbfs.dfsEnabled";
 
     private static final String SCHEME = "smb";
 
@@ -88,7 +89,8 @@ public class SmbFileSystemProvider extends FileSystemProvider {
                 port = SMBClient.DEFAULT_PORT;
             }
 
-            SmbFileSystem fileSystem = factory.create(this, extractHost(uri), port, context, extractShareName(uri));
+            boolean dfsEnabled = extractDfsEnabled(env);
+            SmbFileSystem fileSystem = factory.create(this, extractHost(uri), port, context, extractShareName(uri), dfsEnabled);
             fileSystems.put(key, fileSystem);
             return fileSystem;
         }
@@ -170,6 +172,20 @@ public class SmbFileSystemProvider extends FileSystemProvider {
         }
 
         return uriAuth.getUsername();
+    }
+
+    private boolean extractDfsEnabled(Map<String, ?> env) {
+        if (env.containsKey(DFS_ENABLED_PROPERTY)) {
+            Object value = env.get(DFS_ENABLED_PROPERTY);
+            if (value instanceof Boolean) {
+                return (Boolean) value;
+            } else if (value instanceof String) {
+                return Boolean.parseBoolean((String) value);
+            } else {
+                throw new IllegalArgumentException(DFS_ENABLED_PROPERTY + " must be a Boolean or String");
+            }
+        }
+        return false;
     }
 
     private char[] extractPassword(AuthenticationContext uriAuth, Map<String, ?> env) {
@@ -357,17 +373,17 @@ public class SmbFileSystemProvider extends FileSystemProvider {
 
     interface Factory {
         SmbFileSystem create(SmbFileSystemProvider provider, String host, int port, AuthenticationContext context,
-                             String shareName);
+                             String shareName, boolean dfsEnabled);
     }
 
     private static class FactoryImpl implements Factory {
 
         @Override
         public SmbFileSystem create(SmbFileSystemProvider provider, String host, int port,
-                                    AuthenticationContext context, String shareName) {
+                                    AuthenticationContext context, String shareName, boolean dfsEnabled) {
 
             SmbConfig config = SmbConfig.builder()
-                .withDfsEnabled(true)
+                .withDfsEnabled(dfsEnabled)
                 .build();
 
             ShareSourceImpl shares = new ShareSourceImpl(new SMBClient(config), host, port, context);

--- a/src/test/java/com/hierynomus/smbfs/SmbFileSystemProviderTest.java
+++ b/src/test/java/com/hierynomus/smbfs/SmbFileSystemProviderTest.java
@@ -38,9 +38,11 @@ import java.nio.file.FileSystemNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hierynomus.smbfs.SmbFileSystemProvider.DFS_ENABLED_PROPERTY;
 import static com.hierynomus.smbfs.SmbFileSystemProvider.DOMAIN_PROPERTY;
 import static com.hierynomus.smbfs.SmbFileSystemProvider.PASSWORD_PROPERTY;
 import static com.hierynomus.smbfs.SmbFileSystemProvider.USERNAME_PROPERTY;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,12 +100,44 @@ class SmbFileSystemProviderTest {
 
         @Test
         void createsFileSystem() throws Exception {
-            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), any(), eq(SHARE_NAME)))
+            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), any(), eq(SHARE_NAME), eq(false)))
                 .thenReturn(fileSystem);
 
             SmbFileSystem fs = provider.newFileSystem(uri, emptyMap());
 
             assertSame(fileSystem, fs);
+        }
+
+        @Test
+        void enablesDfsWhenPropertyIsTrue() throws Exception {
+            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), any(), eq(SHARE_NAME), eq(true)))
+                .thenReturn(fileSystem);
+
+            Map<String, Object> env = new HashMap<>();
+            env.put(DFS_ENABLED_PROPERTY, true);
+            SmbFileSystem fs = provider.newFileSystem(uri, env);
+
+            assertSame(fileSystem, fs);
+        }
+
+        @Test
+        void enablesDfsWhenPropertyIsStringTrue() throws Exception {
+            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), any(), eq(SHARE_NAME), eq(true)))
+                .thenReturn(fileSystem);
+
+            Map<String, Object> env = new HashMap<>();
+            env.put(DFS_ENABLED_PROPERTY, "true");
+            SmbFileSystem fs = provider.newFileSystem(uri, env);
+
+            assertSame(fileSystem, fs);
+        }
+
+        @Test
+        void throwsForInvalidDfsEnabledType() {
+            Map<String, Object> env = new HashMap<>();
+            env.put(DFS_ENABLED_PROPERTY, 1);
+
+            assertThrows(IllegalArgumentException.class, () -> provider.newFileSystem(uri, env));
         }
 
         @ParameterizedTest
@@ -117,7 +151,7 @@ class SmbFileSystemProviderTest {
             "dom%3Fain;us%3Fer:pass%3Fword,dom?ain,us?er,pass?word",
         })
         void createsAuthenticationContextFromUri(String uriCredentials, String domain, String username, String password) throws Exception {
-            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), authenticationContexts.capture(), eq(SHARE_NAME)))
+            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), authenticationContexts.capture(), eq(SHARE_NAME), eq(false)))
                 .thenReturn(fileSystem);
 
             URI uri = URI.create("smb://" + uriCredentials + "@server/" + SHARE_NAME);
@@ -142,7 +176,7 @@ class SmbFileSystemProviderTest {
             ",,password2,domain,username,password2",
         })
         void createsAuthenticationContextFromUriAndEnv(String envDomain, String envUsername, String envPassword, String domain, String username, String password) throws Exception {
-            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), authenticationContexts.capture(), eq(SHARE_NAME)))
+            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), authenticationContexts.capture(), eq(SHARE_NAME), eq(false)))
                 .thenReturn(fileSystem);
 
             URI uri = URI.create("smb://domain;username:password@server/" + SHARE_NAME);
@@ -169,7 +203,7 @@ class SmbFileSystemProviderTest {
 
         @Test
         void acceptsCharArrayPassword() throws Exception {
-            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), authenticationContexts.capture(), eq(SHARE_NAME)))
+            when(factory.create(eq(provider), eq("server"), eq(SMBClient.DEFAULT_PORT), authenticationContexts.capture(), eq(SHARE_NAME), eq(false)))
                 .thenReturn(fileSystem);
 
             Map<String, Object> env = new HashMap<>();
@@ -203,7 +237,7 @@ class SmbFileSystemProviderTest {
 
         @BeforeEach
         void setUp() throws Exception {
-            when(factory.create(eq(provider), any(), anyInt(), any(), any()))
+            when(factory.create(eq(provider), any(), anyInt(), any(), any(), anyBoolean()))
                 .thenReturn(fileSystem, fileSystem2);
 
             provider.newFileSystem(uri, emptyMap());


### PR DESCRIPTION
The main basis for these changes are to test access to DFS paths through the SmbFileSystem. Most of them work, just copying/moving between 2 DFS shares fail, as SmbFileSystem treats them as the same share, but they're not. Planning on fixing this next, as we've started to use DFS shares more heavily at my employer.

It also moves creation of the samba container, which was already using the dockerfile rather than the inline dockerfile in java, into build.gradle as this reduces build time a little as there's no need to fire up docker build from test containers.

Finally, it upgrades testcontainers so it works with the latest version of docker.