### PR TITLE
smbfs: add serialVersionUID and tighten InvalidShareException visibility

### DIFF
--- a/src/main/java/com/hierynomus/smbfs/InvalidShareException.java
+++ b/src/main/java/com/hierynomus/smbfs/InvalidShareException.java
@@ -19,7 +19,10 @@ package com.hierynomus.smbfs;
  * Thrown to indicate the share specified in the URI is invalid.
  */
 public class InvalidShareException extends RuntimeException {
-    public InvalidShareException(String message) {
+
+    private static final long serialVersionUID = 1L;
+
+    InvalidShareException(String message) {
         super(message);
     }
 }

--- a/src/main/java/com/hierynomus/smbfs/ToBeImplementedException.java
+++ b/src/main/java/com/hierynomus/smbfs/ToBeImplementedException.java
@@ -17,6 +17,8 @@ package com.hierynomus.smbfs;
 
 public class ToBeImplementedException extends UnsupportedOperationException {
 
+    private static final long serialVersionUID = 1L;
+
     private ToBeImplementedException() {
     }
 


### PR DESCRIPTION
- InvalidShareException/ToBeImplementedException are missing serialVersionUID (Serializable via RuntimeException/UnsupportedOperationException).
- InvalidShareException's constructor is only ever used within com.hierynomus.smbfs; tighten to package-private.