### PR TITLE
smbfs: reuse connection/session/share instead of reconnecting per operation

### DIFF
--- a/src/main/java/com/hierynomus/smbfs/ShareSource.java
+++ b/src/main/java/com/hierynomus/smbfs/ShareSource.java
@@ -20,12 +20,12 @@ import com.hierynomus.smbj.share.DiskShare;
 import java.io.Closeable;
 import java.io.IOException;
 
+/**
+ * Provides access to a (reused) {@link DiskShare}. Unlike a plain connection-per-call
+ * approach, an implementation is expected to keep the underlying connection/session/share
+ * alive across calls to {@link #getShare(String)} and only reconnect when needed.
+ */
 interface ShareSource extends Closeable {
 
-    Holder open(String name) throws IOException;
-
-    interface Holder extends Closeable {
-
-        DiskShare share();
-    }
+    DiskShare getShare(String name) throws IOException;
 }

--- a/src/main/java/com/hierynomus/smbfs/ShareSourceImpl.java
+++ b/src/main/java/com/hierynomus/smbfs/ShareSourceImpl.java
@@ -15,14 +15,22 @@
  */
 package com.hierynomus.smbfs;
 
+import com.hierynomus.protocol.transport.TransportException;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.auth.AuthenticationContext;
+import com.hierynomus.smbj.common.SMBRuntimeException;
 import com.hierynomus.smbj.connection.Connection;
 import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskShare;
 
 import java.io.IOException;
 
+/**
+ * Keeps a single {@link Session}/{@link DiskShare} alive across calls instead of
+ * opening a new connection/session/tree-connect for every single filesystem
+ * operation. If the underlying connection was dropped (a {@link TransportException}),
+ * a single reconnect attempt is made transparently.
+ */
 class ShareSourceImpl implements ShareSource {
 
     private final SMBClient client;
@@ -32,6 +40,9 @@ class ShareSourceImpl implements ShareSource {
 
     private volatile boolean closed = false;
 
+    private Session session;
+    private DiskShare share;
+
     ShareSourceImpl(SMBClient client, String host, int port, AuthenticationContext context) {
         this.client = client;
         this.host = host;
@@ -40,43 +51,62 @@ class ShareSourceImpl implements ShareSource {
     }
 
     @Override
-    public Holder open(String name) throws IOException {
+    public synchronized DiskShare getShare(String name) throws IOException {
         if (closed) {
             throw new IllegalStateException("Already closed");
         }
 
-        Connection connection = client.connect(host, port);
-        Session session = connection.authenticate(context);
+        return getShare(name, true);
+    }
 
-        return new HolderImpl((DiskShare) session.connectShare(name));
+    private DiskShare getShare(String name, boolean retryOnTransportFailure) throws IOException {
+        try {
+            if (share == null || !share.isConnected()) {
+                share = (DiskShare) getSession().connectShare(name);
+            }
+
+            return share;
+        } catch (SMBRuntimeException e) {
+            if (retryOnTransportFailure && e.getCause() instanceof TransportException) {
+                closeSession();
+                return getShare(name, false);
+            }
+
+            throw e;
+        }
+    }
+
+    private Session getSession() throws IOException {
+        if (session == null) {
+            Connection connection = client.connect(host, port);
+            session = connection.authenticate(context);
+        }
+
+        return session;
+    }
+
+    private void closeSession() {
+        if (session != null) {
+            // this will close the session, then connection - handling any suppressed exceptions, etc.
+            try (Connection c = session.getConnection();
+                 Session s = session) {
+                // no-op, just to trigger close() on both
+            } catch (IOException ignored) {
+                // best-effort cleanup before reconnecting
+            } finally {
+                session = null;
+                share = null;
+            }
+        }
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         closed = true;
-        client.close();
-    }
-
-    private static class HolderImpl implements Holder {
-
-        private final DiskShare share;
-
-        private HolderImpl(DiskShare share) {
-            this.share = share;
-        }
-
-        @Override
-        public DiskShare share() {
-            return share;
-        }
-
-        @Override
-        public void close() throws IOException {
-            try (Connection c = share.getTreeConnect().getSession().getConnection();
-                Session s = share.getTreeConnect().getSession()) {
-
-                share.close();
-            }
+        try {
+            closeSession();
+        } finally {
+            client.close();
         }
     }
 }

--- a/src/main/java/com/hierynomus/smbfs/SmbFileChannel.java
+++ b/src/main/java/com/hierynomus/smbfs/SmbFileChannel.java
@@ -27,14 +27,12 @@ class SmbFileChannel implements SeekableByteChannel {
 
     private final ReentrantLock lock = new ReentrantLock();
 
-    private final ShareSource.Holder holder;
     private final File file;
 
     private long position;
     private final AtomicBoolean closed = new AtomicBoolean();
 
-    SmbFileChannel(ShareSource.Holder holder, File file, long position) {
-        this.holder = holder;
+    SmbFileChannel(File file, long position) {
         this.file = file;
         this.position = position;
     }
@@ -113,9 +111,8 @@ class SmbFileChannel implements SeekableByteChannel {
             return;
         }
 
-        try (ShareSource.Holder h = holder;
-             File f = file) {
-            // close the share and file
-        }
+        // the underlying share/session is owned (and reused) by the ShareSource,
+        // only the file handle belongs to this channel.
+        file.close();
     }
 }

--- a/src/main/java/com/hierynomus/smbfs/SmbFileSystem.java
+++ b/src/main/java/com/hierynomus/smbfs/SmbFileSystem.java
@@ -190,36 +190,33 @@ public class SmbFileSystem extends FileSystem {
     DirectoryStream<Path> newDirectoryStream(Path path, DirectoryStream.Filter<? super Path> filter)
         throws IOException {
 
-        try (ShareSource.Holder hol = shares.open(share);
-             DiskShare ds = hol.share()) {
-            List<Path> list = new ArrayList<>();
+        DiskShare ds = shares.getShare(share);
+        List<Path> list = new ArrayList<>();
 
-            for (FileIdBothDirectoryInformation each : ds.list(path.toString())) {
-                String name = each.getFileName();
-                if (name.equals(".") || name.equals("..")) {
-                    continue;
-                }
-
-                Path eachPath = path.resolve(name);
-
-                if (!filter.accept(eachPath)) {
-                    continue;
-                }
-
-                list.add(eachPath);
+        for (FileIdBothDirectoryInformation each : ds.list(path.toString())) {
+            String name = each.getFileName();
+            if (name.equals(".") || name.equals("..")) {
+                continue;
             }
 
-            return new SmbDirectoryStream(list);
+            Path eachPath = path.resolve(name);
+
+            if (!filter.accept(eachPath)) {
+                continue;
+            }
+
+            list.add(eachPath);
         }
+
+        return new SmbDirectoryStream(list);
     }
 
     void createDirectory(Path dir, FileAttribute<?>[] attrs) throws IOException {
 
         EnumSet<AccessMask> accessMasks = EnumSet.of(FILE_LIST_DIRECTORY, FILE_ADD_SUBDIRECTORY);
 
-        try (ShareSource.Holder hol = shares.open(share);
-             DiskShare ds = hol.share();
-             Directory dirDir = ds.openDirectory(dir.toString(), accessMasks, null, null, FILE_CREATE, null)) {
+        DiskShare ds = shares.getShare(share);
+        try (Directory dirDir = ds.openDirectory(dir.toString(), accessMasks, null, null, FILE_CREATE, null)) {
 
             // do-nothing - dir will get created with the open call above
         } catch (SMBApiException e) {
@@ -234,12 +231,10 @@ public class SmbFileSystem extends FileSystem {
         }
 
         try {
-            try (ShareSource.Holder hol = shares.open(share);
-                 DiskShare ds = hol.share()) {
-                FileAllInformation fileInformation = ds.getFileInformation(path.toString());
+            DiskShare ds = shares.getShare(share);
+            FileAllInformation fileInformation = ds.getFileInformation(path.toString());
 
-                return type.cast(new SmbFileAttributes(fileInformation));
-            }
+            return type.cast(new SmbFileAttributes(fileInformation));
         } catch (SMBApiException e) {
             throw new IOException(e);
         }
@@ -251,10 +246,8 @@ public class SmbFileSystem extends FileSystem {
         }
 
         try {
-            try (ShareSource.Holder hol = shares.open(share);
-                 DiskShare ds = hol.share()) {
-                ds.getFileInformation(path.toString());
-            }
+            DiskShare ds = shares.getShare(share);
+            ds.getFileInformation(path.toString());
         } catch (SMBApiException e) {
             if (e.getStatus() == STATUS_OBJECT_PATH_NOT_FOUND || e.getStatus() == STATUS_OBJECT_NAME_NOT_FOUND) {
                 throw new NoSuchFileException(path.toString());
@@ -271,15 +264,14 @@ public class SmbFileSystem extends FileSystem {
         SMB2CreateDisposition disposition = createDisposition(options);
         Set<SMB2CreateOptions> createOptions = createOptions(options);
 
-        ShareSource.Holder hol = shares.open(share);
-        File file = hol.share()
-            .openFile(path.toString(), accessMasks, null, null, disposition, createOptions);
+        DiskShare ds = shares.getShare(share);
+        File file = ds.openFile(path.toString(), accessMasks, null, null, disposition, createOptions);
         long position = 0;
         if (options.contains(StandardOpenOption.APPEND)) {
             position = file.getLength();
         }
 
-        return new SmbFileChannel(hol, file, position);
+        return new SmbFileChannel(file, position);
     }
 
     private static Set<AccessMask> accessMasks(Set<? extends OpenOption> options) {
@@ -337,9 +329,8 @@ public class SmbFileSystem extends FileSystem {
         Set<StandardOpenOption> readOptions = Collections.singleton(StandardOpenOption.READ);
         Set<StandardOpenOption> writeOptions = new HashSet<>(Arrays.asList(StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW));
 
-        try (ShareSource.Holder hol = shares.open(share);
-             DiskShare ds = hol.share();
-             File sourceFile = ds.openFile(source.toString(), accessMasks(readOptions), null, null, createDisposition(readOptions), createOptions(readOptions));
+        DiskShare ds = shares.getShare(share);
+        try (File sourceFile = ds.openFile(source.toString(), accessMasks(readOptions), null, null, createDisposition(readOptions), createOptions(readOptions));
              File destinationFile = ds.openFile(target.toString(), accessMasks(writeOptions), null, null, createDisposition(writeOptions), createOptions(writeOptions))) {
 
             sourceFile.remoteCopyTo(destinationFile);
@@ -352,9 +343,8 @@ public class SmbFileSystem extends FileSystem {
     public void move(SmbPath source, SmbPath target) throws IOException {
         Set<AccessMask> accessMasks = EnumSet.of(AccessMask.FILE_WRITE_ATTRIBUTES);
 
-        try (ShareSource.Holder hol = shares.open(share);
-             DiskShare ds = hol.share();
-             File sourceFile = ds.openFile(source.toString(), accessMasks, null, null, null, null)) {
+        DiskShare ds = shares.getShare(share);
+        try (File sourceFile = ds.openFile(source.toString(), accessMasks, null, null, null, null)) {
 
             sourceFile.rename(target.toString());
         }
@@ -363,9 +353,8 @@ public class SmbFileSystem extends FileSystem {
     public void delete(SmbPath path) throws IOException {
         Set<AccessMask> accessMasks = EnumSet.of(AccessMask.DELETE);
 
-        try (ShareSource.Holder hol = shares.open(share);
-             DiskShare ds = hol.share();
-             File sourceFile = ds.openFile(path.toString(), accessMasks, null, null, null, null)) {
+        DiskShare ds = shares.getShare(share);
+        try (File sourceFile = ds.openFile(path.toString(), accessMasks, null, null, null, null)) {
 
             sourceFile.deleteOnClose();
         }

--- a/src/test/java/com/hierynomus/smbfs/ShareSourceImplTest.java
+++ b/src/test/java/com/hierynomus/smbfs/ShareSourceImplTest.java
@@ -15,21 +15,40 @@
  */
 package com.hierynomus.smbfs;
 
+import com.hierynomus.protocol.transport.TransportException;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.auth.AuthenticationContext;
+import com.hierynomus.smbj.common.SMBRuntimeException;
+import com.hierynomus.smbj.connection.Connection;
+import com.hierynomus.smbj.session.Session;
+import com.hierynomus.smbj.share.DiskShare;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ShareSourceImplTest {
 
     @Mock
     private SMBClient smbClient;
+
+    @Mock
+    private Connection connection;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private DiskShare diskShare;
 
     @Test
     void closeShutsDownClient() throws Exception {
@@ -46,6 +65,51 @@ class ShareSourceImplTest {
 
         source.close();
 
-        assertThrows(IllegalStateException.class, () -> source.open("share"));
+        assertThrows(IllegalStateException.class, () -> source.getShare("share"));
+    }
+
+    @Test
+    void reusesTheSameConnectionSessionAndShare() throws Exception {
+        when(smbClient.connect(anyString(), anyInt())).thenReturn(connection);
+        when(connection.authenticate(any())).thenReturn(session);
+        when(session.connectShare("share")).thenReturn(diskShare);
+        when(diskShare.isConnected()).thenReturn(true);
+
+        ShareSourceImpl source = new ShareSourceImpl(smbClient, "host", 445, AuthenticationContext.anonymous());
+
+        DiskShare first = source.getShare("share");
+        DiskShare second = source.getShare("share");
+
+        assertSame(diskShare, first);
+        assertSame(diskShare, second);
+        verify(smbClient).connect("host", 445);
+        verify(connection).authenticate(any());
+        verify(session).connectShare("share");
+    }
+
+    @Test
+    void reconnectsOnceAfterTransportFailure() throws Exception {
+        DiskShare reconnectedShare = mock(DiskShare.class);
+        Connection secondConnection = mock(Connection.class);
+        Session secondSession = mock(Session.class);
+
+        when(smbClient.connect(anyString(), anyInt())).thenReturn(connection, secondConnection);
+        when(connection.authenticate(any())).thenReturn(session);
+        when(secondConnection.authenticate(any())).thenReturn(secondSession);
+        when(session.connectShare("share"))
+            .thenThrow(new SMBRuntimeException(new TransportException("connection reset")));
+        when(secondSession.connectShare("share")).thenReturn(reconnectedShare);
+        when(session.getConnection()).thenReturn(connection);
+
+        ShareSourceImpl source = new ShareSourceImpl(smbClient, "host", 445, AuthenticationContext.anonymous());
+
+        DiskShare result = source.getShare("share");
+
+        assertSame(reconnectedShare, result);
+        verify(smbClient, org.mockito.Mockito.times(2)).connect("host", 445);
+    }
+
+    private static <T> T mock(Class<T> type) {
+        return org.mockito.Mockito.mock(type);
     }
 }

--- a/src/test/java/com/hierynomus/smbfs/SmbFileSystemTest.java
+++ b/src/test/java/com/hierynomus/smbfs/SmbFileSystemTest.java
@@ -133,9 +133,6 @@ class SmbFileSystemTest {
     class AccessMaskTests {
 
         @Mock
-        private ShareSource.Holder holder;
-
-        @Mock
         private DiskShare diskShare;
 
         @Mock
@@ -146,8 +143,7 @@ class SmbFileSystemTest {
 
         @BeforeEach
         void setUp() throws Exception {
-            when(shares.open("theShare")).thenReturn(holder);
-            when(holder.share()).thenReturn(diskShare);
+            when(shares.getShare("theShare")).thenReturn(diskShare);
             when(diskShare.openFile(any(), accessMaskCaptor.capture(), any(), any(), any(), any()))
                 .thenReturn(smbFile);
         }


### PR DESCRIPTION
Previously ShareSourceImpl.open() opened a brand new Connection+Session+DiskShare for every single filesystem operation (list, stat, checkAccess, copy, move, delete, and each byte channel), and SmbFileSystem/SmbFileChannel explicitly closed the DiskShare and share/session again right after. This meant every NIO call against an SmbPath paid the full TCP handshake + SMB negotiate + session-setup + tree-connect cost.

ShareSource now exposes getShare(name) which keeps a single lazily created Session/DiskShare alive across calls, reconnecting once if a TransportException indicates the connection was lost. SmbFileSystem no longer closes the DiskShare after each operation, and SmbFileChannel no longer closes the shared connection when an individual file channel is closed - only its own File handle.

The ShareSource.Holder abstraction (package-private, no external users) is removed as it is no longer needed.